### PR TITLE
[Feat] #22 - 카카오 소셜 로그인 구현 및 뷰모델 변경

### DIFF
--- a/Growthook/Growthook.xcodeproj/project.pbxproj
+++ b/Growthook/Growthook.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		03115F802B26FB9A009D1517 /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 03115F7F2B26FB9A009D1517 /* KakaoSDKAuth */; };
 		03115F822B26FB9A009D1517 /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = 03115F812B26FB9A009D1517 /* KakaoSDKUser */; };
+		03115F842B26FCA8009D1517 /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 03115F832B26FCA8009D1517 /* KakaoSDKAuth */; };
+		03115F862B26FCA8009D1517 /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 03115F852B26FCA8009D1517 /* KakaoSDKCommon */; };
+		03115F882B26FCA8009D1517 /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = 03115F872B26FCA8009D1517 /* KakaoSDKUser */; };
 		032213322B14C4EF00FF5CF1 /* UnLockAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032213312B14C4EF00FF5CF1 /* UnLockAlertView.swift */; };
 		0322137A2B17642E00FF5CF1 /* RemoveInsightAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032213792B17642E00FF5CF1 /* RemoveInsightAlertView.swift */; };
 		0322137E2B17731E00FF5CF1 /* RemoveInsightAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0322137D2B17731E00FF5CF1 /* RemoveInsightAlertViewController.swift */; };
@@ -195,8 +198,11 @@
 				03E481172AF2B126002F4CBC /* RxRelay in Frameworks */,
 				03E481222AF2B1DA002F4CBC /* Moya in Frameworks */,
 				03E481152AF2B126002F4CBC /* RxCocoa in Frameworks */,
+				03115F862B26FCA8009D1517 /* KakaoSDKCommon in Frameworks */,
 				03E481242AF2B1DA002F4CBC /* RxMoya in Frameworks */,
 				03E4811C2AF2B130002F4CBC /* Then in Frameworks */,
+				03115F842B26FCA8009D1517 /* KakaoSDKAuth in Frameworks */,
+				03115F882B26FCA8009D1517 /* KakaoSDKUser in Frameworks */,
 				03E4811F2AF2B13A002F4CBC /* SnapKit in Frameworks */,
 				58E75FA02B00B72400512FE2 /* Lottie in Frameworks */,
 				03115F822B26FB9A009D1517 /* KakaoSDKUser in Frameworks */,
@@ -643,6 +649,9 @@
 				58E75F9F2B00B72400512FE2 /* Lottie */,
 				03115F7F2B26FB9A009D1517 /* KakaoSDKAuth */,
 				03115F812B26FB9A009D1517 /* KakaoSDKUser */,
+				03115F832B26FCA8009D1517 /* KakaoSDKAuth */,
+				03115F852B26FCA8009D1517 /* KakaoSDKCommon */,
+				03115F872B26FCA8009D1517 /* KakaoSDKUser */,
 			);
 			productName = Growthook;
 			productReference = 03E480FC2AF2AFDC002F4CBC /* Growthook.app */;
@@ -1066,6 +1075,21 @@
 			productName = KakaoSDKAuth;
 		};
 		03115F812B26FB9A009D1517 /* KakaoSDKUser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 03115F7E2B26FB9A009D1517 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKUser;
+		};
+		03115F832B26FCA8009D1517 /* KakaoSDKAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 03115F7E2B26FB9A009D1517 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKAuth;
+		};
+		03115F852B26FCA8009D1517 /* KakaoSDKCommon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 03115F7E2B26FB9A009D1517 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKCommon;
+		};
+		03115F872B26FCA8009D1517 /* KakaoSDKUser */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 03115F7E2B26FB9A009D1517 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
 			productName = KakaoSDKUser;

--- a/Growthook/Growthook.xcodeproj/project.pbxproj
+++ b/Growthook/Growthook.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		03115F842B26FCA8009D1517 /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 03115F832B26FCA8009D1517 /* KakaoSDKAuth */; };
 		03115F862B26FCA8009D1517 /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 03115F852B26FCA8009D1517 /* KakaoSDKCommon */; };
 		03115F882B26FCA8009D1517 /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = 03115F872B26FCA8009D1517 /* KakaoSDKUser */; };
+		03115F8C2B27072A009D1517 /* KakaoLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03115F8B2B27072A009D1517 /* KakaoLoginViewController.swift */; };
 		032213322B14C4EF00FF5CF1 /* UnLockAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032213312B14C4EF00FF5CF1 /* UnLockAlertView.swift */; };
 		0322137A2B17642E00FF5CF1 /* RemoveInsightAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032213792B17642E00FF5CF1 /* RemoveInsightAlertView.swift */; };
 		0322137E2B17731E00FF5CF1 /* RemoveInsightAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0322137D2B17731E00FF5CF1 /* RemoveInsightAlertViewController.swift */; };
@@ -104,6 +105,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		03115F8B2B27072A009D1517 /* KakaoLoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KakaoLoginViewController.swift; sourceTree = "<group>"; };
 		032213312B14C4EF00FF5CF1 /* UnLockAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnLockAlertView.swift; sourceTree = "<group>"; };
 		032213792B17642E00FF5CF1 /* RemoveInsightAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveInsightAlertView.swift; sourceTree = "<group>"; };
 		0322137D2B17731E00FF5CF1 /* RemoveInsightAlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoveInsightAlertViewController.swift; sourceTree = "<group>"; };
@@ -213,6 +215,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		03115F892B270698009D1517 /* Onboarding */ = {
+			isa = PBXGroup;
+			children = (
+				03115F8A2B2706AD009D1517 /* ViewControllers */,
+			);
+			path = Onboarding;
+			sourceTree = "<group>";
+		};
+		03115F8A2B2706AD009D1517 /* ViewControllers */ = {
+			isa = PBXGroup;
+			children = (
+				03115F8B2B27072A009D1517 /* KakaoLoginViewController.swift */,
+			);
+			path = ViewControllers;
+			sourceTree = "<group>";
+		};
 		033E9C112AFD2F230051A9E8 /* UIComponents */ = {
 			isa = PBXGroup;
 			children = (
@@ -297,8 +315,9 @@
 		03B9AC4A2AF55E3D00A5751C /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
-				58E75FA42B00C0C700512FE2 /* Insights */,
+				03115F892B270698009D1517 /* Onboarding */,
 				03B9AC982AF7A86800A5751C /* Common */,
+				58E75FA42B00C0C700512FE2 /* Insights */,
 				03B9AC9E2AF7B15E00A5751C /* Home */,
 				03B9ACA22AF7B27600A5751C /* ActionList */,
 				03B9ACA32AF7B28200A5751C /* Mypage */,
@@ -743,6 +762,7 @@
 				03B9AC6E2AF563E200A5751C /* UIImage+.swift in Sources */,
 				03B9AC702AF563F300A5751C /* UIViewController+.swift in Sources */,
 				03C356672B108EB800750758 /* InsightTapViewModel.swift in Sources */,
+				03115F8C2B27072A009D1517 /* KakaoLoginViewController.swift in Sources */,
 				03B9AC7E2AF5652E00A5751C /* UIButton+.swift in Sources */,
 				03B9AC742AF5648900A5751C /* UITextView+.swift in Sources */,
 				58E75FAC2B00C16900512FE2 /* InsightsViewModel.swift in Sources */,

--- a/Growthook/Growthook.xcodeproj/project.pbxproj
+++ b/Growthook/Growthook.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03115F802B26FB9A009D1517 /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 03115F7F2B26FB9A009D1517 /* KakaoSDKAuth */; };
+		03115F822B26FB9A009D1517 /* KakaoSDKUser in Frameworks */ = {isa = PBXBuildFile; productRef = 03115F812B26FB9A009D1517 /* KakaoSDKUser */; };
 		032213322B14C4EF00FF5CF1 /* UnLockAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032213312B14C4EF00FF5CF1 /* UnLockAlertView.swift */; };
 		0322137A2B17642E00FF5CF1 /* RemoveInsightAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032213792B17642E00FF5CF1 /* RemoveInsightAlertView.swift */; };
 		0322137E2B17731E00FF5CF1 /* RemoveInsightAlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0322137D2B17731E00FF5CF1 /* RemoveInsightAlertViewController.swift */; };
@@ -197,6 +199,8 @@
 				03E4811C2AF2B130002F4CBC /* Then in Frameworks */,
 				03E4811F2AF2B13A002F4CBC /* SnapKit in Frameworks */,
 				58E75FA02B00B72400512FE2 /* Lottie in Frameworks */,
+				03115F822B26FB9A009D1517 /* KakaoSDKUser in Frameworks */,
+				03115F802B26FB9A009D1517 /* KakaoSDKAuth in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -637,6 +641,8 @@
 				03E481212AF2B1DA002F4CBC /* Moya */,
 				03E481232AF2B1DA002F4CBC /* RxMoya */,
 				58E75F9F2B00B72400512FE2 /* Lottie */,
+				03115F7F2B26FB9A009D1517 /* KakaoSDKAuth */,
+				03115F812B26FB9A009D1517 /* KakaoSDKUser */,
 			);
 			productName = Growthook;
 			productReference = 03E480FC2AF2AFDC002F4CBC /* Growthook.app */;
@@ -672,6 +678,7 @@
 				03E4811D2AF2B13A002F4CBC /* XCRemoteSwiftPackageReference "SnapKit" */,
 				03E481202AF2B1DA002F4CBC /* XCRemoteSwiftPackageReference "Moya" */,
 				58E75F9E2B00B72400512FE2 /* XCRemoteSwiftPackageReference "lottie-ios" */,
+				03115F7E2B26FB9A009D1517 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 			);
 			productRefGroup = 03E480FD2AF2AFDC002F4CBC /* Products */;
 			projectDirPath = "";
@@ -935,7 +942,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = kwonjeong.Growthookj;
+				PRODUCT_BUNDLE_IDENTIFIER = Growthook;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -967,7 +974,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = kwonjeong.Growthookj;
+				PRODUCT_BUNDLE_IDENTIFIER = Growthook;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -1002,6 +1009,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		03115F7E2B26FB9A009D1517 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kakao/kakao-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.19.0;
+			};
+		};
 		03E481132AF2B126002F4CBC /* XCRemoteSwiftPackageReference "RxSwift" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ReactiveX/RxSwift";
@@ -1045,6 +1060,16 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		03115F7F2B26FB9A009D1517 /* KakaoSDKAuth */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 03115F7E2B26FB9A009D1517 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKAuth;
+		};
+		03115F812B26FB9A009D1517 /* KakaoSDKUser */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 03115F7E2B26FB9A009D1517 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDKUser;
+		};
 		03E481142AF2B126002F4CBC /* RxCocoa */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 03E481132AF2B126002F4CBC /* XCRemoteSwiftPackageReference "RxSwift" */;

--- a/Growthook/Growthook.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Growthook/Growthook.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "revision" : "5840447aabb9512d0ead90f672724e558731abc1",
+        "version" : "2.19.0"
+      }
+    },
+    {
       "identity" : "lottie-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/airbnb/lottie-ios",

--- a/Growthook/Growthook/Application/AppDelegate.swift
+++ b/Growthook/Growthook/Application/AppDelegate.swift
@@ -6,6 +6,8 @@
 //
 
 import UIKit
+import KakaoSDKCommon
+import KakaoSDKAuth
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -14,8 +16,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private(set) var deviceWidth: CGFloat = 0.0
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        KakaoSDK.initSDK(appKey: "843b48c8525110a9a20fecc83354d5a6")
         // Override point for customization after application launch.
         return true
+    }
+    
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+        if (AuthApi.isKakaoTalkLoginUrl(url)) {
+            return AuthController.handleOpenUrl(url: url)
+        }
+        return false
     }
 
     // MARK: UISceneSession Lifecycle

--- a/Growthook/Growthook/Application/SceneDelegate.swift
+++ b/Growthook/Growthook/Application/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
         
-        let splashViewController = TabBarController()
+        let splashViewController = KakaoLoginViewController()
         
         window?.rootViewController = splashViewController
         window?.makeKeyAndVisible()

--- a/Growthook/Growthook/Application/SceneDelegate.swift
+++ b/Growthook/Growthook/Application/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
         
-        let splashViewController = KakaoLoginViewController()
+        let splashViewController = TabBarController()
         
         window?.rootViewController = splashViewController
         window?.makeKeyAndVisible()

--- a/Growthook/Growthook/Application/SceneDelegate.swift
+++ b/Growthook/Growthook/Application/SceneDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import KakaoSDKAuth
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
@@ -20,6 +21,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window?.rootViewController = splashViewController
         window?.makeKeyAndVisible()
+    }
+    
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        if let url = URLContexts.first?.url {
+            if (AuthApi.isKakaoTalkLoginUrl(url)) {
+                _ = AuthController.handleOpenUrl(url: url)
+            }
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Growthook/Growthook/Info.plist
+++ b/Growthook/Growthook/Info.plist
@@ -2,6 +2,30 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao843b48c8525110a9a20fecc83354d5a6</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao843b48c8525110a9a20fecc83354d5a6:ouath</string>
+			</array>
+		</dict>
+	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
+	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/Growthook/Growthook/Presentation/Home/ViewControllers/CaveListHalfModal.swift
+++ b/Growthook/Growthook/Presentation/Home/ViewControllers/CaveListHalfModal.swift
@@ -22,13 +22,13 @@ class CaveListHalfModal: BaseViewController {
     
     // MARK: - Properties
     
-    private let viewModel = CaveListViewModel()
+    private let viewModel = HomeViewModel()
     private let disposeBag = DisposeBag()
     var indexPath: IndexPath? = nil
     private let deSelectInsightNotification = Notification.Name("DeSelectInsightNotification")
     
     override func bindViewModel() {
-        viewModel.outputs.caveList
+        viewModel.outputs.caveProfile
             .bind(to: caveListTableView.rx
                 .items(cellIdentifier: CaveListHalfModalCell.className,
                        cellType: CaveListHalfModalCell.self)) { [weak self] (index, model, cell) in

--- a/Growthook/Growthook/Presentation/Home/ViewModels/HomeViewModel.swift
+++ b/Growthook/Growthook/Presentation/Home/ViewModels/HomeViewModel.swift
@@ -16,6 +16,8 @@ protocol HomeViewModelInputs {
     func reloadInsight()
     func insightCellTap(at indexPath: IndexPath)
     func giveUpButtonTap()
+    func caveListCellTap(at indexPath: IndexPath)
+    func selectButtonTap()
 }
 
 protocol HomeViewModelOutputs {
@@ -24,6 +26,8 @@ protocol HomeViewModelOutputs {
     var insightLongTap: PublishSubject<IndexPath> { get }
     var insightBackground: PublishSubject<IndexPath> { get }
     var pushToInsightDetail: PublishSubject<IndexPath> { get }
+    var selectedCellIndex: BehaviorRelay<IndexPath?> { get }
+    var moveToCave: Observable<Void> { get }
 }
 
 protocol HomeViewModelType {
@@ -40,6 +44,11 @@ final class HomeViewModel: HomeViewModelInputs, HomeViewModelOutputs, HomeViewMo
     let reloadInsightSubject: PublishSubject<Void> = PublishSubject<Void>()
     var pushToInsightDetail: PublishSubject<IndexPath> = PublishSubject<IndexPath>()
     var dismissToHomeVC: PublishSubject<Void> = PublishSubject<Void>()
+    var selectedCellIndex: BehaviorRelay<IndexPath?> = BehaviorRelay<IndexPath?>(value: nil)
+    let buttonTapSubject: PublishSubject<Void> = PublishSubject<Void>()
+    var moveToCave: Observable<Void> {
+        return buttonTapSubject.asObservable()
+    }
     
     var inputs: HomeViewModelInputs { return self }
     var outputs: HomeViewModelOutputs { return self }
@@ -70,5 +79,13 @@ final class HomeViewModel: HomeViewModelInputs, HomeViewModelOutputs, HomeViewMo
     
     func giveUpButtonTap() {
         self.dismissToHomeVC.onNext(())
+    }
+    
+    func caveListCellTap(at indexPath: IndexPath) {
+        selectedCellIndex.accept(indexPath)
+    }
+    
+    func selectButtonTap() {
+        return buttonTapSubject.onNext(())
     }
 }

--- a/Growthook/Growthook/Presentation/Onboarding/ViewControllers/KakaoLoginViewController.swift
+++ b/Growthook/Growthook/Presentation/Onboarding/ViewControllers/KakaoLoginViewController.swift
@@ -59,10 +59,10 @@ final class KakaoLoginViewController: BaseViewController {
             let userName = user?.kakaoAccount?.name
             let userEmail = user?.kakaoAccount?.email
             
-            let contentText =
-            "user name : \(userName)\n userEmail : \(userEmail)\n"
+            print("userName : ", userName ?? "")
+            print("userEmail : ", userEmail ?? "")
             
-            print("user - \(user)")
+            self.loginSuccess()
             
             if userEmail == nil {
                 // 동의 안함
@@ -97,6 +97,18 @@ final class KakaoLoginViewController: BaseViewController {
                     self.kakaoGetUserInfo()
                 }
             }
+        }
+    }
+    
+    private func loginSuccess() {
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+           let sceneDelegate = windowScene.delegate as? SceneDelegate,
+           let window = sceneDelegate.window {
+            let vc = TabBarController()
+            let rootVC = UINavigationController(rootViewController: vc)
+            rootVC.navigationController?.isNavigationBarHidden = true
+            window.rootViewController = rootVC
+            window.makeKeyAndVisible()
         }
     }
 }

--- a/Growthook/Growthook/Presentation/Onboarding/ViewControllers/KakaoLoginViewController.swift
+++ b/Growthook/Growthook/Presentation/Onboarding/ViewControllers/KakaoLoginViewController.swift
@@ -1,0 +1,102 @@
+//
+//  KakaoLoginViewController.swift
+//  Growthook
+//
+//  Created by KJ on 12/11/23.
+//
+
+import UIKit
+
+import Then
+import SnapKit
+import RxSwift
+import RxCocoa
+import KakaoSDKAuth
+import KakaoSDKUser
+
+final class KakaoLoginViewController: BaseViewController {
+
+    private let loginButton = UIButton()
+    private let disposeBag = DisposeBag()
+    
+    override func bindViewModel() {
+        loginButton.rx.tap
+            .subscribe(onNext: { [weak self] in
+                self?.kakaoLogin()
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    override func setStyles() {
+        
+        loginButton.do {
+            $0.setTitle("카카오로그인", for: .normal)
+            $0.backgroundColor = .yellow
+            $0.setTitleColor(.black000, for: .normal)
+            $0.makeCornerRound(radius: 15)
+        }
+    }
+    
+    override func setLayout() {
+        
+        self.view.addSubviews(loginButton)
+        
+        loginButton.snp.makeConstraints {
+            $0.bottom.equalToSuperview().inset(100)
+            $0.horizontalEdges.equalToSuperview().inset(50)
+            $0.height.equalTo(100)
+        }
+    }
+    
+    /// 사용자 정보 가져오기
+    private func kakaoGetUserInfo() {
+        
+        UserApi.shared.me() { (user, error) in
+            if let error = error {
+                print(error)
+            }
+            
+            let userName = user?.kakaoAccount?.name
+            let userEmail = user?.kakaoAccount?.email
+            
+            let contentText =
+            "user name : \(userName)\n userEmail : \(userEmail)\n"
+            
+            print("user - \(user)")
+            
+            if userEmail == nil {
+                // 동의 안함
+                return
+            }
+            
+//            self.textField.text = contentText
+        }
+    }
+    
+    private func kakaoLogin() {
+        if (UserApi.isKakaoTalkLoginAvailable()) {
+            UserApi.shared.loginWithKakaoTalk {(oauthToken, error) in
+                if let error = error {
+                    print(error)
+                }
+                else {
+                    print("✉️ loginWithKakaoTalk() success.")
+
+                   //let idToken = oAuthToken.idToken ?? ""
+                   //let accessToken = oAuthToken.accessToken
+                   
+                    self.kakaoGetUserInfo()
+                }
+            }
+        } else {
+            UserApi.shared.loginWithKakaoAccount { (oauthToken, error) in
+                if let error = error {
+                    print(error)
+                } else {
+                    print("✉️ loginWithKakaoAccount() success.")
+                    self.kakaoGetUserInfo()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🌿 문제

<!-- 작업하게 된 배경을 간단히 적어주세요! -->
- 카카오 소셜 로그인 구현
- 뷰모델 변경

## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 저번 PR 때 규보오빠의 말을 반영해 뷰모델을 수정했습니다.
- 카카오 소셜 로그인을 구현했습니다. 아직 온보딩 뷰가 없어 임시로 ViewController를 구현했습니다.

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 카카오톡 미설치시 | <img src = "https://github.com/Team-Growthook/Growthook-iOS/assets/48792069/c42beac9-50c5-4b36-b122-077fafef549b" width ="250">|

https://github.com/Team-Growthook/Growthook-iOS/assets/48792069/e7fce508-6cca-4ff2-bf27-1f394aec7052
- 카카오톡 설치시


## 🍀 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #22 
