### PR TITLE
[Feat] #63 - 카카오로그인 구현 및 인사이트 잠금 해제 로직 수정

### DIFF
--- a/Growthook/Growthook.xcodeproj/project.pbxproj
+++ b/Growthook/Growthook.xcodeproj/project.pbxproj
@@ -645,7 +645,6 @@
 				092A51892B52D2C100296B46 /* CreateCave */,
 				586626112B4E65590084468C /* Insights */,
 				5866260C2B4E65410084468C /* MyPage */,
-				03B9AC612AF5624D00A5751C /* DTO.swift */,
 			);
 			path = Data;
 			sourceTree = "<group>";
@@ -791,7 +790,6 @@
 				586626172B4E65810084468C /* Insights */,
 				586626162B4E65780084468C /* MyPage */,
 				093C1DF82B4C311E00EF84AB /* CreateCave */,
-				03B9AC5F2AF561AD00A5751C /* API.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -1093,13 +1091,6 @@
 			children = (
 			);
 			path = Auth;
-			sourceTree = "<group>";
-		};
-		259E7F882B4A755E00F3DC8F /* DTO */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = DTO;
 			sourceTree = "<group>";
 		};
 		259E7F9A2B4FCA7B00F3DC8F /* ActionList */ = {
@@ -1544,7 +1535,6 @@
 				032213822B17960700FF5CF1 /* NotificationAlertView.swift in Sources */,
 				584EDAD72B4A57E60094872A /* Observable+.swift in Sources */,
 				58EFF5DB2B445AB6003C3838 /* BaseTargetType.swift in Sources */,
-				03B9AC602AF561AD00A5751C /* API.swift in Sources */,
 				588E2B4F2B53BBAF0014E6D5 /* InsightsDetailActionPlanCollectionViewCell.swift in Sources */,
 				582F9C4A2B304B720000D161 /* TextViewBlockWithTitle.swift in Sources */,
 				2568FA182B0DD47E00CAD12A /* ActionListBottomSheetViewController.swift in Sources */,

--- a/Growthook/Growthook.xcodeproj/project.pbxproj
+++ b/Growthook/Growthook.xcodeproj/project.pbxproj
@@ -35,6 +35,8 @@
 		033E9C1B2AFE606E0051A9E8 /* CaveCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033E9C1A2AFE606E0051A9E8 /* CaveCollectionViewCell.swift */; };
 		033E9C1E2AFE63D40051A9E8 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033E9C1D2AFE63D40051A9E8 /* HomeViewModel.swift */; };
 		033E9C202AFE725D0051A9E8 /* CaveProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033E9C1F2AFE725D0051A9E8 /* CaveProfile.swift */; };
+		034011352B58DCF200D1F371 /* AuthTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034011342B58DCF200D1F371 /* AuthTarget.swift */; };
+		034011382B58E03F00D1F371 /* LoginRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034011372B58E03F00D1F371 /* LoginRequestDto.swift */; };
 		03431ACF2B3D51220017EA52 /* Encodable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03431ACE2B3D51220017EA52 /* Encodable+.swift */; };
 		034580822B2D628F002DDEBA /* CaveDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034580812B2D628F002DDEBA /* CaveDetailViewController.swift */; };
 		034580852B2D6354002DDEBA /* CaveDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034580842B2D6354002DDEBA /* CaveDetailView.swift */; };
@@ -226,6 +228,8 @@
 		033E9C1A2AFE606E0051A9E8 /* CaveCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaveCollectionViewCell.swift; sourceTree = "<group>"; };
 		033E9C1D2AFE63D40051A9E8 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		033E9C1F2AFE725D0051A9E8 /* CaveProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaveProfile.swift; sourceTree = "<group>"; };
+		034011342B58DCF200D1F371 /* AuthTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthTarget.swift; sourceTree = "<group>"; };
+		034011372B58E03F00D1F371 /* LoginRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRequestDto.swift; sourceTree = "<group>"; };
 		03431ACE2B3D51220017EA52 /* Encodable+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+.swift"; sourceTree = "<group>"; };
 		034580812B2D628F002DDEBA /* CaveDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaveDetailViewController.swift; sourceTree = "<group>"; };
 		034580842B2D6354002DDEBA /* CaveDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaveDetailView.swift; sourceTree = "<group>"; };
@@ -525,6 +529,22 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
+		034011332B58DCD100D1F371 /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				034011342B58DCF200D1F371 /* AuthTarget.swift */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
+		034011362B58E02000D1F371 /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				034011372B58E03F00D1F371 /* LoginRequestDto.swift */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
 		0345807F2B2D6260002DDEBA /* CaveDetail */ = {
 			isa = PBXGroup;
 			children = (
@@ -590,6 +610,7 @@
 		035701EE2B4EF35000A9E47A /* APIService */ = {
 			isa = PBXGroup;
 			children = (
+				034011332B58DCD100D1F371 /* Auth */,
 				0332A3962B5135D200720CD3 /* Home */,
 				0332A3972B5135DC00720CD3 /* Cave */,
 				0332A3982B5135E400720CD3 /* Ssuk */,
@@ -638,6 +659,7 @@
 		03B9AC492AF55E3300A5751C /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				034011362B58E02000D1F371 /* Auth */,
 				259E7F9A2B4FCA7B00F3DC8F /* ActionList */,
 				0332A3932B51357E00720CD3 /* Ssuk */,
 				035701EB2B4EBED500A9E47A /* Insight */,
@@ -1478,6 +1500,7 @@
 				250F7D752B14624300D9726F /* ActionListReviewViewController.swift in Sources */,
 				588E2B422B539EE50014E6D5 /* InsightsDetailService.swift in Sources */,
 				58E75F982B00B15A00512FE2 /* BaseViewController.swift in Sources */,
+				034011382B58E03F00D1F371 /* LoginRequestDto.swift in Sources */,
 				5880F4672B3423B8004C1494 /* InsightSelectCaveTableViewCell.swift in Sources */,
 				09089A6A2B03B3E2006C07B8 /* AlertBuilder.swift in Sources */,
 				092AE2B52B53DA6300E9A20D /* Int+.swift in Sources */,
@@ -1527,6 +1550,7 @@
 				03B9AC7C2AF5651600A5751C /* UITabBar+.swift in Sources */,
 				03B9AC862AF565BA00A5751C /* SizeLiterals.swift in Sources */,
 				035701E12B4E6DA700A9E47A /* CaveListEmptyView.swift in Sources */,
+				034011352B58DCF200D1F371 /* AuthTarget.swift in Sources */,
 				035701EA2B4EBA9600A9E47A /* CaveListResponseDto.swift in Sources */,
 				03B9ACA12AF7B25B00A5751C /* HomeViewController.swift in Sources */,
 				252DD8842B063A7900DBB1D1 /* ActionListViewModel.swift in Sources */,

--- a/Growthook/Growthook.xcodeproj/project.pbxproj
+++ b/Growthook/Growthook.xcodeproj/project.pbxproj
@@ -37,6 +37,9 @@
 		033E9C202AFE725D0051A9E8 /* CaveProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033E9C1F2AFE725D0051A9E8 /* CaveProfile.swift */; };
 		034011352B58DCF200D1F371 /* AuthTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034011342B58DCF200D1F371 /* AuthTarget.swift */; };
 		034011382B58E03F00D1F371 /* LoginRequestDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034011372B58E03F00D1F371 /* LoginRequestDto.swift */; };
+		0340113B2B58E5C600D1F371 /* AuthAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0340113A2B58E5C600D1F371 /* AuthAPI.swift */; };
+		0340113D2B58E65400D1F371 /* LoginResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0340113C2B58E65400D1F371 /* LoginResponseDto.swift */; };
+		0340113F2B58E68000D1F371 /* RefreshTokenResponseDto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0340113E2B58E68000D1F371 /* RefreshTokenResponseDto.swift */; };
 		03431ACF2B3D51220017EA52 /* Encodable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03431ACE2B3D51220017EA52 /* Encodable+.swift */; };
 		034580822B2D628F002DDEBA /* CaveDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034580812B2D628F002DDEBA /* CaveDetailViewController.swift */; };
 		034580852B2D6354002DDEBA /* CaveDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034580842B2D6354002DDEBA /* CaveDetailView.swift */; };
@@ -230,6 +233,9 @@
 		033E9C1F2AFE725D0051A9E8 /* CaveProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaveProfile.swift; sourceTree = "<group>"; };
 		034011342B58DCF200D1F371 /* AuthTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthTarget.swift; sourceTree = "<group>"; };
 		034011372B58E03F00D1F371 /* LoginRequestDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRequestDto.swift; sourceTree = "<group>"; };
+		0340113A2B58E5C600D1F371 /* AuthAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthAPI.swift; sourceTree = "<group>"; };
+		0340113C2B58E65400D1F371 /* LoginResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginResponseDto.swift; sourceTree = "<group>"; };
+		0340113E2B58E68000D1F371 /* RefreshTokenResponseDto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshTokenResponseDto.swift; sourceTree = "<group>"; };
 		03431ACE2B3D51220017EA52 /* Encodable+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+.swift"; sourceTree = "<group>"; };
 		034580812B2D628F002DDEBA /* CaveDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaveDetailViewController.swift; sourceTree = "<group>"; };
 		034580842B2D6354002DDEBA /* CaveDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaveDetailView.swift; sourceTree = "<group>"; };
@@ -541,6 +547,16 @@
 			isa = PBXGroup;
 			children = (
 				034011372B58E03F00D1F371 /* LoginRequestDto.swift */,
+				0340113C2B58E65400D1F371 /* LoginResponseDto.swift */,
+				0340113E2B58E68000D1F371 /* RefreshTokenResponseDto.swift */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
+		034011392B58E5AF00D1F371 /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				0340113A2B58E5C600D1F371 /* AuthAPI.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -803,7 +819,7 @@
 		03B9AC5E2AF561A200A5751C /* API */ = {
 			isa = PBXGroup;
 			children = (
-				259E7F872B4A6FAA00F3DC8F /* Auth */,
+				034011392B58E5AF00D1F371 /* Auth */,
 				259E7F862B4A6FA100F3DC8F /* ActionList */,
 				0332A39B2B5136F400720CD3 /* SsukAPI */,
 				0332A38E2B5020BD00720CD3 /* CaveAPI */,
@@ -1106,13 +1122,6 @@
 				259E7F902B4A7BCA00F3DC8F /* ActionListService.swift */,
 			);
 			path = ActionList;
-			sourceTree = "<group>";
-		};
-		259E7F872B4A6FAA00F3DC8F /* Auth */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Auth;
 			sourceTree = "<group>";
 		};
 		259E7F9A2B4FCA7B00F3DC8F /* ActionList */ = {
@@ -1488,6 +1497,7 @@
 				09A7D7002B00DED0005F8821 /* CreateCaveViewModel.swift in Sources */,
 				586626152B4E65720084468C /* InsightsModel.swift in Sources */,
 				581D22982B3356150068E58D /* SelectBlockWithTitle.swift in Sources */,
+				0340113D2B58E65400D1F371 /* LoginResponseDto.swift in Sources */,
 				0332A38B2B501D7000720CD3 /* CaveDetailResponseDto.swift in Sources */,
 				03B9AC842AF565A300A5751C /* ImageLiterals.swift in Sources */,
 				035701E32B4E7C6600A9E47A /* CaveDetailMenuBottomSheet.swift in Sources */,
@@ -1508,6 +1518,7 @@
 				09CE00F52B0DB9CC00CB42C4 /* InsightModel.swift in Sources */,
 				09CE00F02B0DB1FB00CB42C4 /* CreateActionViewControlller.swift in Sources */,
 				03B9AC932AF566B300A5751C /* ButtonPress.swift in Sources */,
+				0340113F2B58E68000D1F371 /* RefreshTokenResponseDto.swift in Sources */,
 				092C816D2B334E13006B0F65 /* CreateSpecificPlanView .swift in Sources */,
 				586626242B4E996C0084468C /* FullCoverLoadingView.swift in Sources */,
 				034580822B2D628F002DDEBA /* CaveDetailViewController.swift in Sources */,
@@ -1515,6 +1526,7 @@
 				259E7F722B3E95F600F3DC8F /* LoginView.swift in Sources */,
 				03B9AC6E2AF563E200A5751C /* UIImage+.swift in Sources */,
 				03B9AC702AF563F300A5751C /* UIViewController+.swift in Sources */,
+				0340113B2B58E5C600D1F371 /* AuthAPI.swift in Sources */,
 				58AB70AC2B2C7CC50061C072 /* MyPageViewModel.swift in Sources */,
 				581D228E2B320C630068E58D /* CommonTextFieldWithBorder.swift in Sources */,
 				0332A39D2B51370000720CD3 /* SsukAPI.swift in Sources */,

--- a/Growthook/Growthook/Application/AppDelegate.swift
+++ b/Growthook/Growthook/Application/AppDelegate.swift
@@ -16,7 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private(set) var deviceWidth: CGFloat = 0.0
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        KakaoSDK.initSDK(appKey: "843b48c8525110a9a20fecc83354d5a6")
+        KakaoSDK.initSDK(appKey: "c00637515b500899429161caf885cb12")
         // Override point for customization after application launch.
         return true
     }

--- a/Growthook/Growthook/Application/SceneDelegate.swift
+++ b/Growthook/Growthook/Application/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
         
-        let splashViewController = TabBarController()
+        let splashViewController = LoginViewController()
         
         window?.rootViewController = splashViewController
         window?.makeKeyAndVisible()

--- a/Growthook/Growthook/Data/Auth/LoginRequestDto.swift
+++ b/Growthook/Growthook/Data/Auth/LoginRequestDto.swift
@@ -1,0 +1,13 @@
+//
+//  LoginRequestDto.swift
+//  Growthook
+//
+//  Created by KJ on 1/18/24.
+//
+
+import Foundation
+
+struct LoginRequestDto: Codable {
+    let socialPlatform: String
+    let socialToken: String
+}

--- a/Growthook/Growthook/Data/Auth/LoginResponseDto.swift
+++ b/Growthook/Growthook/Data/Auth/LoginResponseDto.swift
@@ -1,0 +1,15 @@
+//
+//  LoginResponseDto.swift
+//  Growthook
+//
+//  Created by KJ on 1/18/24.
+//
+
+import Foundation
+
+struct LoginResponseDto: Codable {
+    let nickname: String
+    let memberId: Int
+    let accessToken: String
+    let refreshToken: String
+}

--- a/Growthook/Growthook/Data/Auth/RefreshTokenResponseDto.swift
+++ b/Growthook/Growthook/Data/Auth/RefreshTokenResponseDto.swift
@@ -1,0 +1,13 @@
+//
+//  RefreshTokenResponseDto.swift
+//  Growthook
+//
+//  Created by KJ on 1/18/24.
+//
+
+import Foundation
+
+struct RefreshTokenResponseDto: Codable {
+    let accessToken: String
+    let refreshToken: String
+}

--- a/Growthook/Growthook/Data/Cave/CaveListResponseDto.swift
+++ b/Growthook/Growthook/Data/Cave/CaveListResponseDto.swift
@@ -10,4 +10,5 @@ import Foundation
 struct CaveListResponseDto: Codable {
     let caveId: Int
     let caveName: String
+    let caveImageIndex: Int
 }

--- a/Growthook/Growthook/Global/Literals/StringLiterals.swift
+++ b/Growthook/Growthook/Global/Literals/StringLiterals.swift
@@ -102,4 +102,10 @@ enum I18N {
         static let referencePlaceholder = "출처의 정보를 입력해주세요"
         static let referenceUrlPlaceholder = "참고한 url을 적어주세요 (선택)"
     }
+    
+    enum Auth {
+        static let kakao = "KAKAO"
+        static let nickname = "nickname"
+        static let memberId = "memberId"
+    }
 }

--- a/Growthook/Growthook/Network/API/Auth/AuthAPI.swift
+++ b/Growthook/Growthook/Network/API/Auth/AuthAPI.swift
@@ -1,0 +1,61 @@
+//
+//  AuthAPI.swift
+//  Growthook
+//
+//  Created by KJ on 1/18/24.
+//
+
+import Moya
+
+final class AuthAPI {
+    static let shared: AuthAPI = AuthAPI()
+    
+    private let authProvider = MoyaProvider<AuthTarget>(plugins: [NetworkLoggerPlugin()])
+    
+    private init() {}
+    
+    public private(set) var authData: GeneralResponse<LoginResponseDto>?
+    public private(set) var refreshTokenData: GeneralResponse<RefreshTokenResponseDto>?
+    
+    // MARK: - POST
+    /// 카카오 로그인
+    func postKakaoLogin(param: LoginRequestDto, completion: @escaping (GeneralResponse<LoginResponseDto>?) -> Void) {
+        authProvider.request(.login(param: param)) {
+            result in
+            switch result {
+            case .success(let response):
+                do {
+                    self.authData = try response.map(GeneralResponse<LoginResponseDto>?.self)
+                    guard let authData = self.authData else { return }
+                    completion(authData)
+                } catch let err {
+                    print(err.localizedDescription, 500)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
+            }
+        }
+    }
+    
+    // MARK: - GET
+    /// 토큰 재발급
+    func getRefreshToken(completion: @escaping (GeneralResponse<RefreshTokenResponseDto>?) -> Void) {
+        authProvider.request(.tokenRefresh) {
+            result in
+            switch result {
+            case .success(let response):
+                do {
+                    self.refreshTokenData = try response.map(GeneralResponse<RefreshTokenResponseDto>?.self)
+                    guard let refreshTokenData = self.refreshTokenData else { return }
+                    completion(refreshTokenData)
+                } catch let err {
+                    print(err.localizedDescription, 500)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+                completion(nil)
+            }
+        }
+    }
+}

--- a/Growthook/Growthook/Network/API/Auth/AuthAPI.swift
+++ b/Growthook/Growthook/Network/API/Auth/AuthAPI.swift
@@ -60,14 +60,4 @@ final class AuthAPI {
             }
         }
     }
-    
-    private func getNewToken() {
-        AuthAPI.shared.getRefreshToken() { [weak self] response in
-            guard self != nil else { return }
-            guard let data = response?.data else { return }
-            APIConstants.jwtToken = data.accessToken
-            APIConstants.refreshToken = data.refreshToken
-            
-        }
-    }
 }

--- a/Growthook/Growthook/Network/API/Auth/AuthAPI.swift
+++ b/Growthook/Growthook/Network/API/Auth/AuthAPI.swift
@@ -6,6 +6,7 @@
 //
 
 import Moya
+import Foundation
 
 final class AuthAPI {
     static let shared: AuthAPI = AuthAPI()
@@ -24,13 +25,14 @@ final class AuthAPI {
             result in
             switch result {
             case .success(let response):
-                do {
-                    self.authData = try response.map(GeneralResponse<LoginResponseDto>?.self)
-                    guard let authData = self.authData else { return }
-                    completion(authData)
-                } catch let err {
-                    print(err.localizedDescription, 500)
-                }
+                let status = response.statusCode
+                    do {
+                        self.authData = try response.map(GeneralResponse<LoginResponseDto>?.self)
+                        guard let authData = self.authData else { return }
+                        completion(authData)
+                    } catch let err {
+                        print(err.localizedDescription, 500)
+                    }
             case .failure(let err):
                 print(err.localizedDescription)
                 completion(nil)
@@ -56,6 +58,16 @@ final class AuthAPI {
                 print(err.localizedDescription)
                 completion(nil)
             }
+        }
+    }
+    
+    private func getNewToken() {
+        AuthAPI.shared.getRefreshToken() { [weak self] response in
+            guard self != nil else { return }
+            guard let data = response?.data else { return }
+            APIConstants.jwtToken = data.accessToken
+            APIConstants.refreshToken = data.refreshToken
+            
         }
     }
 }

--- a/Growthook/Growthook/Network/APIService/Auth/AuthTarget.swift
+++ b/Growthook/Growthook/Network/APIService/Auth/AuthTarget.swift
@@ -1,0 +1,54 @@
+//
+//  AuthTarget.swift
+//  Growthook
+//
+//  Created by KJ on 1/18/24.
+//
+
+import Foundation
+
+import Moya
+
+enum AuthTarget {
+    case login(param: LoginRequestDto)
+    case tokenRefresh
+}
+
+extension AuthTarget: BaseTargetType {
+    
+    var path: String {
+        switch self {
+        case .login:
+            return URLConstant.socialLogin
+        case .tokenRefresh:
+            return URLConstant.tokenRefresh
+        }
+    }
+    
+    var method: Moya.Method {
+        switch self {
+        case .login:
+            return .post
+        case .tokenRefresh:
+            return .get
+        }
+    }
+    
+    var task: Moya.Task {
+        switch self {
+        case .login(let param):
+            return .requestParameters(parameters: try! param.asParameter(), encoding: JSONEncoding.default)
+        case .tokenRefresh:
+            return .requestPlain
+        }
+    }
+    
+    var headers: [String : String]? {
+        switch self {
+        case .login(_):
+            return APIConstants.headerWithDeviceToken
+        case .tokenRefresh:
+            return APIConstants.headerWithRefresh
+        }
+    }
+}

--- a/Growthook/Growthook/Network/APIService/Auth/AuthTarget.swift
+++ b/Growthook/Growthook/Network/APIService/Auth/AuthTarget.swift
@@ -46,7 +46,7 @@ extension AuthTarget: BaseTargetType {
     var headers: [String : String]? {
         switch self {
         case .login(_):
-            return APIConstants.headerWithDeviceToken
+            return APIConstants.headerWithOutToken
         case .tokenRefresh:
             return APIConstants.headerWithRefresh
         }

--- a/Growthook/Growthook/Network/APIService/Cave/CaveTarget.swift
+++ b/Growthook/Growthook/Network/APIService/Cave/CaveTarget.swift
@@ -64,6 +64,6 @@ extension CaveTarget: BaseTargetType {
     }
     
     var headers: [String : String]? {
-        return APIConstants.headerWithOutToken
+        return APIConstants.headerWithAuthorization
     }
 }

--- a/Growthook/Growthook/Network/APIService/Home/SeedListTarget.swift
+++ b/Growthook/Growthook/Network/APIService/Home/SeedListTarget.swift
@@ -85,7 +85,7 @@ extension SeedListTarget: BaseTargetType {
     }
     
     var headers: [String : String]? {
-        return APIConstants.headerWithOutToken
+        return APIConstants.headerWithAuthorization
     }
 }
 

--- a/Growthook/Growthook/Network/APIService/Ssuk/SsukTarget.swift
+++ b/Growthook/Growthook/Network/APIService/Ssuk/SsukTarget.swift
@@ -44,7 +44,7 @@ extension SsukTarget: BaseTargetType {
     }
     
     var headers: [String : String]? {
-        return APIConstants.headerWithOutToken
+        return APIConstants.headerWithAuthorization
     }
 }
 

--- a/Growthook/Growthook/Network/Base/APIConstant.swift
+++ b/Growthook/Growthook/Network/Base/APIConstant.swift
@@ -34,21 +34,21 @@ enum APIConstants {
     static var headerWithDeviceToken: [String: String] {
         [
             NetworkHeaderKey.contentType.rawValue: APIConstants.applicationJSON,
-            NetworkHeaderKey.authorization.rawValue: APIConstants.jwtToken
+            NetworkHeaderKey.authorization.rawValue: URLConstant.bearer + APIConstants.deviceToken
         ]
     }
     
     static var headerWithAuthorization: [String: String] {
         [
             NetworkHeaderKey.contentType.rawValue: APIConstants.applicationJSON,
-            NetworkHeaderKey.authorization.rawValue: APIConstants.jwtToken
+            NetworkHeaderKey.authorization.rawValue: URLConstant.bearer + APIConstants.jwtToken
         ]
     }
     
     static var headerWithRefresh: [String: String] {
         [
             NetworkHeaderKey.contentType.rawValue: APIConstants.applicationJSON,
-            NetworkHeaderKey.authorization.rawValue: APIConstants.jwtToken
+            NetworkHeaderKey.authorization.rawValue: URLConstant.bearer + APIConstants.jwtToken
         ]
     }
 }

--- a/Growthook/Growthook/Network/Base/APIConstant.swift
+++ b/Growthook/Growthook/Network/Base/APIConstant.swift
@@ -21,7 +21,6 @@ enum APIConstants {
     static let applicationJSON = "application/json"
     static var deviceToken: String = ""
     static var jwtToken: String = ""
-    static var memberId: Int = 0
     static var refreshToken: String = ""
     
     //MARK: - Header

--- a/Growthook/Growthook/Network/Base/APIConstant.swift
+++ b/Growthook/Growthook/Network/Base/APIConstant.swift
@@ -22,6 +22,7 @@ enum APIConstants {
     static var deviceToken: String = ""
     static var jwtToken: String = ""
     static var memberId: Int = 4
+    static var refreshToken: String = ""
     
     //MARK: - Header
     

--- a/Growthook/Growthook/Network/Base/APIConstant.swift
+++ b/Growthook/Growthook/Network/Base/APIConstant.swift
@@ -21,7 +21,7 @@ enum APIConstants {
     static let applicationJSON = "application/json"
     static var deviceToken: String = ""
     static var jwtToken: String = ""
-    static var memberId: Int = 4
+    static var memberId: Int = 0
     static var refreshToken: String = ""
     
     //MARK: - Header

--- a/Growthook/Growthook/Network/Base/URLConstant.swift
+++ b/Growthook/Growthook/Network/Base/URLConstant.swift
@@ -61,4 +61,10 @@ enum URLConstant {
     // MARK: - Review
     
     static let review = "/api/v1/actionplan/{actionPlanId}/review"
+    
+    // MARK: - Auth
+    
+    static let socialLogin = "/api/v1/auth"
+    static let tokenRefresh = "/api/v1/auth/token"
+    static let bearer = "Bearer "
 }

--- a/Growthook/Growthook/Presentation/CaveDetail/ViewControllers/CaveDetailViewController.swift
+++ b/Growthook/Growthook/Presentation/CaveDetail/ViewControllers/CaveDetailViewController.swift
@@ -35,6 +35,7 @@ final class CaveDetailViewController: BaseViewController {
     private let disposeBag = DisposeBag()
     private var lockSeedId: Int?
     private var caveId: Int
+    private var lockActionPlan: Bool?
     
     // MARK: - Initializer
 
@@ -146,8 +147,13 @@ final class CaveDetailViewController: BaseViewController {
         
         unLockCaveAlertView.checkButton.rx.tap
             .subscribe(onNext: { [weak self] in
-                self?.unLockCaveAlertView.removeFromSuperview()
-                // TODO: - 인사이트 디테일 이동
+                guard let self else { return }
+                self.unLockCaveAlertView.removeFromSuperview()
+                guard let actionPlan = self.lockActionPlan else { return }
+                guard let seedId = self.lockSeedId else { return }
+                let vc = InsightsDetailViewController(hasAnyActionPlan: actionPlan, seedId: seedId)
+                vc.hidesBottomBarWhenPushed = true
+                self.navigationController?.pushViewController(vc, animated: true)
             })
             .disposed(by: disposeBag)
         
@@ -248,6 +254,7 @@ extension CaveDetailViewController {
                     $0.edges.equalToSuperview()
                 }
                 self.lockSeedId = cell.seedId
+                self.lockActionPlan = cell.hasActionPlan
             } else {
                 let vc = InsightsDetailViewController(hasAnyActionPlan: cell.hasActionPlan, seedId: cell.seedId)
                 vc.hidesBottomBarWhenPushed = true

--- a/Growthook/Growthook/Presentation/Home/Cell/CaveCollectionViewCell.swift
+++ b/Growthook/Growthook/Presentation/Home/Cell/CaveCollectionViewCell.swift
@@ -76,5 +76,24 @@ extension CaveCollectionViewCell {
     func configureCell(_ model: CaveListResponseDto) {
         caveTitle.text = model.caveName
         caveId = model.caveId
+        setCaveImage(model.caveImageIndex)
+    }
+    
+    
+    private func setCaveImage(_ index: Int) {
+        let image: UIImage
+        switch index {
+        case 0:
+            image = ImageLiterals.Home.img_cave_pink
+        case 1:
+            image = ImageLiterals.Home.img_cave_night
+        case 2:
+            image = ImageLiterals.Home.img_cave_sunrise
+        case 3:
+            image = ImageLiterals.Home.img_cave_sunset
+        default:
+            return
+        }
+        caveImageView.image = image
     }
 }

--- a/Growthook/Growthook/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/Growthook/Growthook/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -38,6 +38,7 @@ final class HomeViewController: BaseViewController {
     private let viewModel = HomeViewModel()
     lazy var longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress(_:)))
     private var lockSeedId: Int?
+    private var lockActionPlan: Bool?
     
     // MARK: - View Life Cycle
     
@@ -183,9 +184,13 @@ final class HomeViewController: BaseViewController {
         
         viewModel.outputs.unLockSeed
             .subscribe(onNext: { [weak self] in
-                self?.unLockAlertView.removeFromSuperview()
-                // TODO: - 인사이트 뷰 이동
-                print("인사이트 잠금 해제 뷰 이동")
+                guard let self else { return }
+                self.unLockAlertView.removeFromSuperview()
+                guard let actionPlan = self.lockActionPlan else { return }
+                guard let seedId = self.lockSeedId else { return }
+                let vc = InsightsDetailViewController(hasAnyActionPlan: actionPlan, seedId: seedId)
+                vc.hidesBottomBarWhenPushed = true
+                self.navigationController?.pushViewController(vc, animated: true)
             })
             .disposed(by: disposeBag)
         
@@ -362,6 +367,7 @@ extension HomeViewController {
                     $0.edges.equalToSuperview()
                 }
                 self.lockSeedId = cell.seedId
+                self.lockActionPlan = cell.hasActionPlan
             } else {
                 let vc = InsightsDetailViewController(hasAnyActionPlan: cell.hasActionPlan, seedId: cell.seedId)
                 vc.hidesBottomBarWhenPushed = true

--- a/Growthook/Growthook/Presentation/Home/ViewModels/HomeViewModel.swift
+++ b/Growthook/Growthook/Presentation/Home/ViewModels/HomeViewModel.swift
@@ -87,7 +87,7 @@ final class HomeViewModel: HomeViewModelInputs, HomeViewModelOutputs, HomeViewMo
     private var selectedSeedId: Int?
     var insightModel: [SeedListResponseDto] = []
     private var caveId: Int?
-    var memberId: Int = APIConstants.memberId
+    var memberId: Int = UserDefaults.standard.integer(forKey: I18N.Auth.memberId)
     
     // 인사이트 선택
     var presentToCaveList: PublishSubject<Void> = PublishSubject<Void>()

--- a/Growthook/Growthook/Presentation/Home/Views/HomeCaveView.swift
+++ b/Growthook/Growthook/Presentation/Home/Views/HomeCaveView.swift
@@ -29,6 +29,10 @@ final class HomeCaveView: BaseView {
     private let underLineView = UIView()
     private let flowLayout = UICollectionViewFlowLayout()
     
+    // MARK: - Properties
+    
+    private let userName: String = UserDefaults.standard.string(forKey: I18N.Auth.nickname) ?? ""
+    
     // MARK: - UI Components Property
     
     override func setStyles() {
@@ -36,7 +40,7 @@ final class HomeCaveView: BaseView {
         backgroundColor = .clear
         
         userLabel.do {
-            $0.text = "EON\(I18N.Home.userCave)"
+            $0.text = "\(userName)\(I18N.Home.userCave)"
             $0.font = .fontGuide(.head1)
             $0.textColor = .white000
         }

--- a/Growthook/Growthook/Presentation/Onboarding/ViewControllers/LoginViewController.swift
+++ b/Growthook/Growthook/Presentation/Onboarding/ViewControllers/LoginViewController.swift
@@ -85,11 +85,6 @@ final class LoginViewController: BaseViewController {
                     print("✉️ loginWithKakaoTalk() success.")
                     guard let accessToken = oauthToken?.accessToken else { return }
                     APIConstants.deviceToken = "Bearer " + accessToken
-                    print("⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️")
-                    print(APIConstants.deviceToken)
-                    
-                    //let idToken = oAuthToken.idToken ?? ""
-                    //let accessToken = oAuthToken.accessToken
                     self.postKakaoLogin()
                 }
             }
@@ -99,10 +94,8 @@ final class LoginViewController: BaseViewController {
                     print(error)
                 } else {
                     print("✉️ loginWithKakaoAccount() success.")
-                    print("⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️")
                     guard let accessToken = oauthToken?.accessToken else { return }
                     APIConstants.deviceToken = "Bearer " + accessToken
-                    print(APIConstants.deviceToken)
                     self.postKakaoLogin()
                 }
             }

--- a/Growthook/Growthook/Presentation/Onboarding/ViewControllers/LoginViewController.swift
+++ b/Growthook/Growthook/Presentation/Onboarding/ViewControllers/LoginViewController.swift
@@ -85,7 +85,7 @@ final class LoginViewController: BaseViewController {
             
             let userName = user?.kakaoAccount?.name
             let userEmail = user?.kakaoAccount?.email
-            
+            print("⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️")
             print("userName : ", userName ?? "")
             print("userEmail : ", userEmail ?? "")
             
@@ -108,6 +108,10 @@ final class LoginViewController: BaseViewController {
                 }
                 else {
                     print("✉️ loginWithKakaoTalk() success.")
+                    guard let accessToken = oauthToken?.accessToken else { return }
+                    APIConstants.deviceToken = accessToken
+                    print("⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️")
+                    print(APIConstants.deviceToken)
                     
                     //let idToken = oAuthToken.idToken ?? ""
                     //let accessToken = oAuthToken.accessToken
@@ -121,6 +125,10 @@ final class LoginViewController: BaseViewController {
                     print(error)
                 } else {
                     print("✉️ loginWithKakaoAccount() success.")
+                    print("⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️")
+                    guard let accessToken = oauthToken?.accessToken else { return }
+                    APIConstants.deviceToken = accessToken
+                    print(APIConstants.deviceToken)
                     self.kakaoGetUserInfo()
                 }
             }

--- a/Growthook/Growthook/Presentation/Onboarding/ViewControllers/LoginViewController.swift
+++ b/Growthook/Growthook/Presentation/Onboarding/ViewControllers/LoginViewController.swift
@@ -84,7 +84,7 @@ final class LoginViewController: BaseViewController {
                 else {
                     print("✉️ loginWithKakaoTalk() success.")
                     guard let accessToken = oauthToken?.accessToken else { return }
-                    APIConstants.deviceToken = "Bearer " + accessToken
+                    APIConstants.deviceToken = URLConstant.bearer + accessToken
                     self.postKakaoLogin()
                 }
             }
@@ -95,7 +95,7 @@ final class LoginViewController: BaseViewController {
                 } else {
                     print("✉️ loginWithKakaoAccount() success.")
                     guard let accessToken = oauthToken?.accessToken else { return }
-                    APIConstants.deviceToken = "Bearer " + accessToken
+                    APIConstants.deviceToken = URLConstant.bearer + accessToken
                     self.postKakaoLogin()
                 }
             }

--- a/Growthook/Growthook/Presentation/Onboarding/ViewControllers/LoginViewController.swift
+++ b/Growthook/Growthook/Presentation/Onboarding/ViewControllers/LoginViewController.swift
@@ -115,7 +115,7 @@ final class LoginViewController: BaseViewController {
     }
     
     private func postKakaoLogin() {
-        let model: LoginRequestDto = LoginRequestDto(socialPlatform: "KAKAO", socialToken: APIConstants.deviceToken)
+        let model: LoginRequestDto = LoginRequestDto(socialPlatform: I18N.Auth.kakao, socialToken: APIConstants.deviceToken)
         AuthAPI.shared.postKakaoLogin(param: model) { [weak self]
             response in
             guard let status = response?.status else { return }
@@ -128,9 +128,8 @@ final class LoginViewController: BaseViewController {
             guard let data = response?.data else { return }
             APIConstants.jwtToken = data.accessToken
             APIConstants.refreshToken = data.refreshToken
-            UserDefaults.standard.set(data.nickname, forKey: "nickname")
-            UserDefaults.standard.set(data.memberId, forKey: "memberId")
-            APIConstants.memberId = data.memberId
+            UserDefaults.standard.set(data.nickname, forKey: I18N.Auth.nickname)
+            UserDefaults.standard.set(data.memberId, forKey: I18N.Auth.memberId)
             self?.loginSuccess()
         }
     }


### PR DESCRIPTION
## 🌿 문제

<!-- 작업하게 된 배경을 간단히 적어주세요! -->
- 카카오로그인 구현
- 인사이트 잠금 해제 서버통신에서 액션플랜유무와 씨앗아이디를 전달해주어야 해서 이를 수정했습니다.

## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 카카오로그인 API
- 토큰재발급 API
- 사용자 정보를 UserDefault에 저장해놓았습니다! 필요하실 때 쓰시면 될 것 같아요
- 서버통신 헤더 부분을 수정했습니다. APIService 헤더 부분을 `return APIConstants.headerWithAuthorization`로 수정하셔야 할 거에요

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/Team-Growthook/Growthook-iOS/assets/48792069/a0d51673-63e4-4922-a8f4-dc3e368ae387" width ="250">|

## 🍀 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #63 
