### PR TITLE
[Fix] #69 - 홈, 동굴 상세 뷰 오류 수정

### DIFF
--- a/Growthook/Growthook/Application/SceneDelegate.swift
+++ b/Growthook/Growthook/Application/SceneDelegate.swift
@@ -17,7 +17,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
         
-        let splashViewController = LoginViewController()
+        let splashViewController = SplashViewController()
         
         window?.rootViewController = splashViewController
         window?.makeKeyAndVisible()

--- a/Growthook/Growthook/Global/Literals/StringLiterals.swift
+++ b/Growthook/Growthook/Global/Literals/StringLiterals.swift
@@ -107,5 +107,6 @@ enum I18N {
         static let kakao = "KAKAO"
         static let nickname = "nickname"
         static let memberId = "memberId"
+        static let jwtToken = "jwtToken"
     }
 }

--- a/Growthook/Growthook/Network/Base/APIConstant.swift
+++ b/Growthook/Growthook/Network/Base/APIConstant.swift
@@ -20,7 +20,7 @@ enum APIConstants {
     static let auth: String = "x-auth-token"
     static let applicationJSON = "application/json"
     static var deviceToken: String = ""
-    static var jwtToken: String = ""
+    static var jwtToken: String = UserDefaults.standard.string(forKey: I18N.Auth.jwtToken) ?? ""
     static var refreshToken: String = ""
     
     //MARK: - Header

--- a/Growthook/Growthook/Presentation/CaveDetail/ViewControllers/CaveDetailViewController.swift
+++ b/Growthook/Growthook/Presentation/CaveDetail/ViewControllers/CaveDetailViewController.swift
@@ -284,23 +284,7 @@ extension CaveDetailViewController {
     
     func presentToHalfModalViewController(_ indexPath: IndexPath) {
         let insightTapVC = InsightTapBottomSheet(viewModel: viewModel)
-        insightTapVC.modalPresentationStyle = .pageSheet
-        let customDetentIdentifier = UISheetPresentationController.Detent.Identifier(I18N.Component.Identifier.type)
-        let customDetent = UISheetPresentationController.Detent.custom(identifier: customDetentIdentifier) { (_) in
-            return SizeLiterals.Screen.screenHeight * 84 / 812
-        }
-        
-        if let sheet = insightTapVC.sheetPresentationController {
-            sheet.detents = [customDetent]
-            sheet.preferredCornerRadius = 0
-            sheet.delegate = self
-            sheet.delegate = insightTapVC as? any UISheetPresentationControllerDelegate
-        }
-        
-        insightTapVC.onDismiss = { [weak self] in
-            self?.viewModel.inputs.dismissInsightTap(at: indexPath)
-        }
-        
+        insightTapVC.modalPresentationStyle = .overFullScreen
         insightTapVC.indexPath = indexPath
         present(insightTapVC, animated: true)
     }

--- a/Growthook/Growthook/Presentation/CaveDetail/ViewControllers/CaveDetailViewController.swift
+++ b/Growthook/Growthook/Presentation/CaveDetail/ViewControllers/CaveDetailViewController.swift
@@ -116,18 +116,18 @@ final class CaveDetailViewController: BaseViewController {
             })
             .disposed(by: disposeBag)
         
-        unLockInsightAlertView.useButton.rx.tap
-            .subscribe(onNext: { [weak self] in
-                guard let seedId = self?.lockSeedId else { return }
-                self?.viewModel.inputs.unLockSeedAlert(seedId: seedId)
-            })
-            .disposed(by: disposeBag)
+//        unLockInsightAlertView.useButton.rx.tap
+//            .subscribe(onNext: { [weak self] in
+//                guard let seedId = self?.lockSeedId else { return }
+//                self?.viewModel.inputs.unLockSeedAlert(seedId: seedId)
+//            })
+//            .disposed(by: disposeBag)
         
-        unLockInsightAlertView.giveUpButton.rx.tap
-            .subscribe(onNext: { [weak self] in
-                self?.unLockInsightAlertView.removeFromSuperview()
-            })
-            .disposed(by: disposeBag)
+//        unLockInsightAlertView.giveUpButton.rx.tap
+//            .subscribe(onNext: { [weak self] in
+//                self?.unLockInsightAlertView.removeFromSuperview()
+//            })
+//            .disposed(by: disposeBag)
         
         caveDetailView.insightListView.scrapButton.rx.tap
             .subscribe(onNext: { [weak self] in
@@ -181,7 +181,8 @@ final class CaveDetailViewController: BaseViewController {
             .subscribe(onNext: { [weak self] in
                 guard let caveId = self?.caveId else { return }
                 guard let viewModel = self?.viewModel else { return }
-                self?.navigationController?.pushViewController(ChangeCaveViewController(caveId: caveId, homeViewModel: viewModel), animated: true)
+                let vc = ChangeCaveViewController(caveId: caveId, homeViewModel: viewModel)
+                self?.navigationController?.pushViewController(vc, animated: true)
             })
             .disposed(by: disposeBag)
     }

--- a/Growthook/Growthook/Presentation/CaveDetail/ViewControllers/ChangeCaveViewController.swift
+++ b/Growthook/Growthook/Presentation/CaveDetail/ViewControllers/ChangeCaveViewController.swift
@@ -18,7 +18,7 @@ final class ChangeCaveViewController: BaseViewController {
     // MARK: - UI Components
     
     private let changeCaveView = ChangeCaveView()
-    private let vieWModel = ChangeCaveViewModel()
+    private let viewModel = ChangeCaveViewModel()
     private let disposeBag = DisposeBag()
     private let homeViewModel: HomeViewModel
     
@@ -52,7 +52,7 @@ final class ChangeCaveViewController: BaseViewController {
             .distinctUntilChanged()
             .bind { [weak self] value in
                 guard let self else { return }
-                self.vieWModel.inputs.setName(value: value)
+                self.viewModel.inputs.setName(value: value)
             }
             .disposed(by: disposeBag)
         
@@ -88,11 +88,11 @@ final class ChangeCaveViewController: BaseViewController {
             .distinctUntilChanged()
             .bind { [weak self] value in
                 guard let self else { return }
-                self.vieWModel.inputs.setIntroduce(value: value)
+                self.viewModel.inputs.setIntroduce(value: value)
             }
             .disposed(by: disposeBag)
         
-        vieWModel.outputs.isValid
+        viewModel.outputs.isValid
             .map { $0 ? true : false }
             .bind(to: changeCaveView.navigationBar.rx.completionEnableStatus)
             .disposed(by: disposeBag)
@@ -106,15 +106,16 @@ final class ChangeCaveViewController: BaseViewController {
         changeCaveView.navigationBar.completionButton.rx.tap
             .subscribe(onNext: { [weak self] in
                 guard let caveId = self?.caveId else { return }
-                self?.vieWModel.inputs.completionButtonTap(caveId: caveId)
+                self?.viewModel.inputs.completionButtonTap(caveId: caveId)
             })
             .disposed(by: disposeBag)
         
-        vieWModel.outputs.changeCave
+        viewModel.outputs.changeCave
             .subscribe(onNext: { [weak self] in
                 guard let self else { return }
                 guard let caveId = self.caveId else { return }
                 self.homeViewModel.inputs.caveDetail(caveId: caveId)
+                self.homeViewModel.inputs.reloadCave()
                 self.popToCaveDetailVC()
             })
             .disposed(by: disposeBag)

--- a/Growthook/Growthook/Presentation/CaveDetail/ViewModels/ChangeCaveViewModel.swift
+++ b/Growthook/Growthook/Presentation/CaveDetail/ViewModels/ChangeCaveViewModel.swift
@@ -41,7 +41,6 @@ final class ChangeCaveViewModel: ChangeCaveViewModelInputs, ChangeCaveViewModelO
     
     func completionButtonTap(caveId: Int) {
         patchCave(caveId: caveId)
-        changeCave.onNext(())
     }
     
     var name: BehaviorRelay<String> = BehaviorRelay(value: "")
@@ -65,7 +64,7 @@ extension ChangeCaveViewModel {
     func patchCave(caveId: Int) {
         let model: CavePatchRequestDto = CavePatchRequestDto(name: name.value, introduction: introduce.value, isShared: false)
         CaveAPI.shared.patch(caveId: caveId, param: model) { [weak self] response in
-            guard self != nil else { return }
+            self?.changeCave.onNext(())
         }
     }
 }

--- a/Growthook/Growthook/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/Growthook/Growthook/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -320,24 +320,6 @@ extension HomeViewController {
     func presentToHalfModalViewController(_ indexPath: IndexPath) {
         let insightTapVC = InsightTapBottomSheet(viewModel: viewModel)
         insightTapVC.modalPresentationStyle = .overFullScreen
-//        let customDetentIdentifier = UISheetPresentationController.Detent.Identifier(I18N.Component.Identifier.customDetent)
-//        let customDetent = UISheetPresentationController.Detent.custom(identifier: customDetentIdentifier) { (_) in
-//            return SizeLiterals.Screen.screenHeight * 84 / 812
-//        }
-//        
-//        if let sheet = insightTapVC.sheetPresentationController {
-//            sheet.detents = [customDetent]
-//            sheet.preferredCornerRadius = 0
-//            sheet.delegate = self
-//            sheet.delegate = insightTapVC as? any UISheetPresentationControllerDelegate
-//        }
-//        
-//        insightTapVC.onDismiss = { [weak self] in
-//            self?.viewModel.inputs.dismissInsightTap(at: indexPath)
-//        }
-        
-        
-        
         insightTapVC.indexPath = indexPath
         present(insightTapVC, animated: true)
     }

--- a/Growthook/Growthook/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/Growthook/Growthook/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -319,22 +319,24 @@ extension HomeViewController {
     
     func presentToHalfModalViewController(_ indexPath: IndexPath) {
         let insightTapVC = InsightTapBottomSheet(viewModel: viewModel)
-        insightTapVC.modalPresentationStyle = .pageSheet
-        let customDetentIdentifier = UISheetPresentationController.Detent.Identifier(I18N.Component.Identifier.customDetent)
-        let customDetent = UISheetPresentationController.Detent.custom(identifier: customDetentIdentifier) { (_) in
-            return SizeLiterals.Screen.screenHeight * 84 / 812
-        }
+        insightTapVC.modalPresentationStyle = .overFullScreen
+//        let customDetentIdentifier = UISheetPresentationController.Detent.Identifier(I18N.Component.Identifier.customDetent)
+//        let customDetent = UISheetPresentationController.Detent.custom(identifier: customDetentIdentifier) { (_) in
+//            return SizeLiterals.Screen.screenHeight * 84 / 812
+//        }
+//        
+//        if let sheet = insightTapVC.sheetPresentationController {
+//            sheet.detents = [customDetent]
+//            sheet.preferredCornerRadius = 0
+//            sheet.delegate = self
+//            sheet.delegate = insightTapVC as? any UISheetPresentationControllerDelegate
+//        }
+//        
+//        insightTapVC.onDismiss = { [weak self] in
+//            self?.viewModel.inputs.dismissInsightTap(at: indexPath)
+//        }
         
-        if let sheet = insightTapVC.sheetPresentationController {
-            sheet.detents = [customDetent]
-            sheet.preferredCornerRadius = 0
-            sheet.delegate = self
-            sheet.delegate = insightTapVC as? any UISheetPresentationControllerDelegate
-        }
         
-        insightTapVC.onDismiss = { [weak self] in
-            self?.viewModel.inputs.dismissInsightTap(at: indexPath)
-        }
         
         insightTapVC.indexPath = indexPath
         present(insightTapVC, animated: true)

--- a/Growthook/Growthook/Presentation/Home/ViewControllers/HomeViewController.swift
+++ b/Growthook/Growthook/Presentation/Home/ViewControllers/HomeViewController.swift
@@ -260,7 +260,7 @@ final class HomeViewController: BaseViewController {
     
     override func setLayout() {
         
-        view.addSubviews(homeCaveView, insightListView, notificationView, insightEmptyView, seedPlusButton)
+        view.addSubviews(homeCaveView, insightListView, insightEmptyView, notificationView, seedPlusButton)
         
         homeCaveView.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide)

--- a/Growthook/Growthook/Presentation/Home/ViewControllers/InsightTapBottomSheet.swift
+++ b/Growthook/Growthook/Presentation/Home/ViewControllers/InsightTapBottomSheet.swift
@@ -36,6 +36,16 @@ final class InsightTapBottomSheet: BaseViewController {
         super.init(nibName: nil, bundle: nil)
     }
     
+    // MARK: - View Life Cycle
+    
+    override func viewDidLoad() {
+        setTapScreen()
+        bindViewModel()
+        setStyles()
+        setLayout()
+        setDelegates()
+    }
+    
     override func bindViewModel() {
         moveButton.rx.tap
             .bind { [weak self] in
@@ -111,6 +121,22 @@ final class InsightTapBottomSheet: BaseViewController {
         self.presentationController?.delegate = self
     }
     
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension InsightTapBottomSheet: UIAdaptivePresentationControllerDelegate {
+    
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        onDismiss?()
+    }
+}
+
+extension InsightTapBottomSheet {
+    
+    // MARK: - Methods
+    
     private func presentToCaveListVC() {
         let caveListVC = CaveListHalfModal(viewModel: viewModel)
         caveListVC.modalPresentationStyle = .pageSheet
@@ -136,14 +162,21 @@ final class InsightTapBottomSheet: BaseViewController {
         self.present(removeInsightAlertVC, animated: false, completion: nil)
     }
     
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    private func setTapScreen() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleBackgroundTap))
+        tapGesture.cancelsTouchesInView = false
+        view.addGestureRecognizer(tapGesture)
     }
-}
-
-extension InsightTapBottomSheet: UIAdaptivePresentationControllerDelegate {
     
-    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        onDismiss?()
+    // MARK: - @objc Methods
+    
+    @objc
+    private func handleBackgroundTap(_ gesture: UITapGestureRecognizer) {
+        let touchLocation = gesture.location(in: self.view)
+        if !buttonView.frame.contains(touchLocation) {
+            guard let indexPath = self.indexPath else { return }
+            viewModel.inputs.dismissInsightTap(at: indexPath)
+            dismiss(animated: true)
+        }
     }
 }

--- a/Growthook/Growthook/Presentation/Home/ViewModels/HomeViewModel.swift
+++ b/Growthook/Growthook/Presentation/Home/ViewModels/HomeViewModel.swift
@@ -15,6 +15,7 @@ protocol HomeViewModelInputs {
     func handleLongPress(at indexPath: IndexPath)
     func dismissInsightTap(at indexPath: IndexPath)
     func reloadInsight()
+    func reloadCave()
     func insightCellTap(at indexPath: IndexPath)
     func giveUpButtonTap()
     func caveListCellTap(at indexPath: IndexPath)
@@ -48,6 +49,7 @@ protocol HomeViewModelOutputs {
     var removeInsightAlertView: PublishSubject<Void> { get }
     var dismissToHome: PublishSubject<Void> { get }
     var removeInsight: PublishSubject<Void> { get }
+    var reloadCaves: PublishSubject<Void>  { get }
     var reloadInsights: PublishSubject<Void> { get }
     var insightScrapToggle: PublishSubject<Void> { get }
     var unLockSeed: PublishSubject<Void> { get }
@@ -71,6 +73,7 @@ final class HomeViewModel: HomeViewModelInputs, HomeViewModelOutputs, HomeViewMo
     var insightList: BehaviorRelay<[SeedListResponseDto]> = BehaviorRelay<[SeedListResponseDto]>(value: [])
     var insightLongTap: PublishSubject<IndexPath> = PublishSubject<IndexPath>()
     var insightBackground: PublishSubject<IndexPath> = PublishSubject<IndexPath>()
+    var reloadCaves: PublishSubject<Void> = PublishSubject<Void>()
     var reloadInsights: PublishSubject<Void> = PublishSubject<Void>()
     var pushToInsightDetail: PublishSubject<IndexPath> = PublishSubject<IndexPath>()
     var dismissToHomeVC: PublishSubject<Void> = PublishSubject<Void>()
@@ -132,6 +135,10 @@ final class HomeViewModel: HomeViewModelInputs, HomeViewModelOutputs, HomeViewMo
     
     func dismissInsightTap(at indexPath: IndexPath) {
         self.insightBackground.onNext(indexPath)
+    }
+    
+    func reloadCave() {
+        self.getCaveList(memberId: memberId)
     }
     
     func reloadInsight() {
@@ -272,6 +279,7 @@ extension HomeViewModel {
             guard self != nil else { return }
             guard let data = response?.data else { return }
             self?.caveDetail.accept(data)
+            print("🐸🐸🐸🐸🐸🐸🐸🐸")
         }
     }
     

--- a/Growthook/Growthook/Presentation/Home/ViewModels/HomeViewModel.swift
+++ b/Growthook/Growthook/Presentation/Home/ViewModels/HomeViewModel.swift
@@ -279,7 +279,6 @@ extension HomeViewModel {
             guard self != nil else { return }
             guard let data = response?.data else { return }
             self?.caveDetail.accept(data)
-            print("🐸🐸🐸🐸🐸🐸🐸🐸")
         }
     }
     

--- a/Growthook/Growthook/Presentation/Onboarding/ViewControllers/LoginViewController.swift
+++ b/Growthook/Growthook/Presentation/Onboarding/ViewControllers/LoginViewController.swift
@@ -130,6 +130,7 @@ final class LoginViewController: BaseViewController {
             APIConstants.refreshToken = data.refreshToken
             UserDefaults.standard.set(data.nickname, forKey: I18N.Auth.nickname)
             UserDefaults.standard.set(data.memberId, forKey: I18N.Auth.memberId)
+            UserDefaults.standard.set(data.accessToken, forKey: I18N.Auth.jwtToken)
             self?.loginSuccess()
         }
     }


### PR DESCRIPTION
## 🌿 문제

<!-- 작업하게 된 배경을 간단히 적어주세요! -->
- 작업하면서 미뤄두었던 오류를 수정했습니다.

## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 인사이트 비었을 때 알림 뷰 가려지는 현상 해결
- 인사이트 선택 후 배경 탭 시 셀 선택해제 딜레이 현상 수정
- 동굴 수정 이후 홈, 동굴 상세 뷰에 내용 반영 구현
- UserDefault에 jwt 토큰 저장

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/Team-Growthook/Growthook-iOS/assets/48792069/bdfae403-5025-476c-b7e3-cd31b2b51fc2" width ="250">|

## 🍀 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #69 
