### PR TITLE
[Fix] #76 - 인사이트 뷰 스크랩 버튼 추가

### DIFF
--- a/Growthook/Growthook/Presentation/CreateAction/View/InsightView.swift
+++ b/Growthook/Growthook/Presentation/CreateAction/View/InsightView.swift
@@ -21,6 +21,17 @@ final class InsightView: BaseView, InsightBoxViewType {
     private let dDayLabel = UILabel()
     private let memoScrollView = UIScrollView()
     private let memoLabel = UILabel()
+    private let scrapButton = UIButton()
+    var isScrap = false {
+        didSet {
+            switch isScrap {
+            case true:
+                scrapButton.setImage(ImageLiterals.Home.btn_scrap_light_on, for: .normal)
+            case false:
+                scrapButton.setImage(ImageLiterals.Home.btn_scrap_light_off, for: .normal)
+            }
+        }
+    }
     
     override func setStyles() {
         self.do {
@@ -76,10 +87,15 @@ final class InsightView: BaseView, InsightBoxViewType {
             $0.numberOfLines = 0
             $0.isHidden = true
         }
+        
+        scrapButton.do {
+            $0.setImage(ImageLiterals.Home.btn_scrap_light_off, for: .normal)
+            $0.isHidden = true
+        }
     }
     
     override func setLayout() {
-        self.addSubviews(nameLabel, insightLabel, divisionLabel, dateLabel, verticalDivisionLabel, dDayLabel, memoScrollView, moreButton)
+        self.addSubviews(nameLabel, insightLabel, divisionLabel, dateLabel, verticalDivisionLabel, dDayLabel, memoScrollView, moreButton, scrapButton)
         memoScrollView.addSubview(memoLabel)
         
         nameLabel.snp.makeConstraints {
@@ -132,6 +148,12 @@ final class InsightView: BaseView, InsightBoxViewType {
             $0.edges.equalToSuperview()
             $0.width.equalTo(memoScrollView.snp.width)
         }
+        
+        scrapButton.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(10)
+            $0.trailing.equalToSuperview().inset(8)
+            $0.size.equalTo(48)
+        }
     }
 }
 
@@ -148,6 +170,7 @@ extension InsightView {
         nameLabel.snp.updateConstraints {
             $0.width.equalTo(nameLabel.frame.width + 14)
         }
+        isScrap = model.isScraped
     }
     
     func showDetail() {
@@ -186,5 +209,9 @@ extension InsightView {
             self.dDayLabel.isHidden = true
             self.memoLabel.isHidden = true
         })
+    }
+    
+    func showScrapButton() {
+        scrapButton.isHidden = false
     }
 }


### PR DESCRIPTION
## 🌿 문제 @PecanPiePOS 

<!-- 작업하게 된 배경을 간단히 적어주세요! -->
- 인사이트 뷰에 스크랩 버튼을 만들었습니다. 
- default는 isHidden 된 상태이기 때문에 사용하시려면 InsightView의 showScrapButton() 메서드를 호출해주세요. 
- Insight뷰 내부에 isScrap이라는 Boolean 변수를 선언하였고, 스크랩 하면 서버통신 후 InsightView의 isScrap을 true or false로 바꿔주시면 버튼의 모양이 바뀝니다. 

## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 
<img width="822" alt="Screenshot 2024-01-24 at 3 16 11 PM" src="https://github.com/Team-Growthook/Growthook-iOS/assets/89457040/ff29694a-2f93-49da-8cf4-63a78277ac53"> 변수 선언부입니다. 


## 📷 스크린샷

<img width="376" alt="Screenshot 2024-01-24 at 3 16 29 PM" src="https://github.com/Team-Growthook/Growthook-iOS/assets/89457040/247d860f-6c7f-4bd3-af91-cde4f3f4b8a2">

다른 정보 없는건 서버통신을 안해와서 그렇습니당.. 실제 액션만들기 뷰에는 스크랩 버튼이 나타나지 않습니다. 

## 🍀 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #76 
