### PR TITLE
[Feature] #71 - 소셜 로그인(APPLE) 기능 구현

### DIFF
--- a/Growthook/Growthook.xcodeproj/project.pbxproj
+++ b/Growthook/Growthook.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		250F7D772B16D01500D9726F /* AlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 250F7D762B16D01500D9726F /* AlertViewController.swift */; };
 		252DD8842B063A7900DBB1D1 /* ActionListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252DD8832B063A7900DBB1D1 /* ActionListViewModel.swift */; };
 		2568FA182B0DD47E00CAD12A /* ActionListBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2568FA172B0DD47E00CAD12A /* ActionListBottomSheetViewController.swift */; };
+		259B5A152B60D1CC00B15204 /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259B5A142B60D1CC00B15204 /* KeychainHelper.swift */; };
 		259E7F702B3E95E600F3DC8F /* OnboardingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259E7F6F2B3E95E600F3DC8F /* OnboardingViewModel.swift */; };
 		259E7F722B3E95F600F3DC8F /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259E7F712B3E95F600F3DC8F /* LoginView.swift */; };
 		259E7F752B405D3800F3DC8F /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259E7F742B405D3800F3DC8F /* OnboardingViewController.swift */; };
@@ -329,6 +330,7 @@
 		250F7D762B16D01500D9726F /* AlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewController.swift; sourceTree = "<group>"; };
 		252DD8832B063A7900DBB1D1 /* ActionListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionListViewModel.swift; sourceTree = "<group>"; };
 		2568FA172B0DD47E00CAD12A /* ActionListBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionListBottomSheetViewController.swift; sourceTree = "<group>"; };
+		259B5A142B60D1CC00B15204 /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
 		259E7F6F2B3E95E600F3DC8F /* OnboardingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewModel.swift; sourceTree = "<group>"; };
 		259E7F712B3E95F600F3DC8F /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		259E7F742B405D3800F3DC8F /* OnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
@@ -657,6 +659,7 @@
 				03E480FF2AF2AFDC002F4CBC /* AppDelegate.swift */,
 				03E481012AF2AFDC002F4CBC /* SceneDelegate.swift */,
 				58E75F9C2B00B63C00512FE2 /* SplashViewController.swift */,
+				259B5A142B60D1CC00B15204 /* KeychainHelper.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -1126,13 +1129,6 @@
 			path = ActionList;
 			sourceTree = "<group>";
 		};
-		259E7F872B4A6FAA00F3DC8F /* Auth */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Auth;
-			sourceTree = "<group>";
-		};
 		259E7F9A2B4FCA7B00F3DC8F /* ActionList */ = {
 			isa = PBXGroup;
 			children = (
@@ -1595,6 +1591,7 @@
 				03B9AC682AF5635800A5751C /* String+.swift in Sources */,
 				0332A3902B5020CC00720CD3 /* CaveAPI.swift in Sources */,
 				033E9C202AFE725D0051A9E8 /* CaveProfile.swift in Sources */,
+				259B5A152B60D1CC00B15204 /* KeychainHelper.swift in Sources */,
 				03B9AC7A2AF564FC00A5751C /* UITableView+.swift in Sources */,
 				032213A52B1C54EB00FF5CF1 /* ScrapOnlyButton.swift in Sources */,
 				03C3565F2B0B702900750758 /* InsightTapBottomSheet.swift in Sources */,

--- a/Growthook/Growthook/Application/KeychainHelper.swift
+++ b/Growthook/Growthook/Application/KeychainHelper.swift
@@ -1,0 +1,65 @@
+//
+//  KeychainHelper.swift
+//  Growthook
+//
+//  Created by 천성우 on 1/24/24.
+//
+
+import Foundation
+
+import Security
+
+class KeychainHelper {
+
+    static func save(key: String, data: Data) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data
+        ]
+
+        SecItemDelete(query as CFDictionary)
+        SecItemAdd(query as CFDictionary, nil)
+    }
+    
+    static func update(key: String, data: Data) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key
+        ]
+
+        let attributes: [String: Any] = [
+            kSecValueData as String: data
+        ]
+
+        SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+    }
+
+    static func load(key: String) -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: kCFBooleanTrue!,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var data: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &data)
+
+        if status == noErr {
+            return data as? Data
+        } else {
+            return nil
+        }
+    }
+
+    static func delete(key: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key
+        ]
+
+        SecItemDelete(query as CFDictionary)
+    }
+}
+

--- a/Growthook/Growthook/Application/KeychainHelper.swift
+++ b/Growthook/Growthook/Application/KeychainHelper.swift
@@ -52,6 +52,14 @@ class KeychainHelper {
             return nil
         }
     }
+    
+    static func loadString(key: String) -> String? {
+        if let data = load(key: key) {
+            return String(data: data, encoding: .utf8)
+        } else {
+            return nil
+        }
+    }
 
     static func delete(key: String) {
         let query: [String: Any] = [

--- a/Growthook/Growthook/Application/SplashViewController.swift
+++ b/Growthook/Growthook/Application/SplashViewController.swift
@@ -19,21 +19,17 @@ final class SplashViewController: BaseViewController {
         super.viewDidAppear(animated)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-            var mainViewController: UIViewController
 
             if self.isUserLoggedIn() {
-                mainViewController = TabBarController()
-                (mainViewController as? TabBarController)?.selectedIndex = 0
+                self.openTabBar()
+                APIConstants.jwtToken = UserDefaults.standard.string(forKey: I18N.Auth.jwtToken) ?? ""
+                APIConstants.refreshToken = UserDefaults.standard.string(forKey: I18N.Auth.refreshToken) ?? ""
             } else if self.isFirstLaunch() {
-                mainViewController = OnboardingSelectViewController()
+                self.openOnboarding()
             } else {
-                mainViewController = OnboardingSelectViewController()
+                self.openOnboarding()
             }
 
-            guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else { return }
-
-            sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: mainViewController)
-            sceneDelegate.window?.makeKeyAndVisible()
         }
     }
     
@@ -104,5 +100,20 @@ final class SplashViewController: BaseViewController {
         return UserDefaults.standard.bool(forKey: "isLoggedIn")
     }
     
+    
+    private func openOnboarding() {
+        let mainViewController = OnboardingSelectViewController()
+        guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else { return }
+        sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: mainViewController)
+        sceneDelegate.window?.makeKeyAndVisible()
+    }
+    
+    private func openTabBar() {
+        let mainViewController = TabBarController()
+        mainViewController.selectedIndex = 0
+        guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else { return }
+        sceneDelegate.window?.rootViewController = UINavigationController(rootViewController: mainViewController)
+        sceneDelegate.window?.makeKeyAndVisible()
+    }
     
 }

--- a/Growthook/Growthook/Global/Extension/Observable+.swift
+++ b/Growthook/Growthook/Global/Extension/Observable+.swift
@@ -49,7 +49,8 @@ extension Observable where Element == Response {
                             guard let data = response?.data else { return }
                             APIConstants.jwtToken = data.accessToken
                             APIConstants.refreshToken = data.refreshToken
-                            
+                            UserDefaults.standard.set(data.accessToken, forKey: I18N.Auth.jwtToken)
+                            UserDefaults.standard.set(data.refreshToken, forKey: I18N.Auth.refreshToken)
                             self?.retryOriginalRequest(observer: observer)
                         }
                     default:

--- a/Growthook/Growthook/Global/Extension/Observable+.swift
+++ b/Growthook/Growthook/Global/Extension/Observable+.swift
@@ -12,7 +12,6 @@ import RxSwift
 
 extension Observable where Element == Response {
     
-    private static let disposeBag = DisposeBag()
     
     /**
      Response 타입을 리턴하는 Observable 로써, statusCode 에 따라 구분합니다.
@@ -38,29 +37,6 @@ extension Observable where Element == Response {
         }
     }
     
-    func mapAuthError() -> Observable<Response> {
-        flatMap { element -> Observable<Response> in
-                .create { observer in
-                    switch element.statusCode {
-                    case 401:
-                        print("Token Expired")
-                        AuthAPI.shared.getRefreshToken() { [weak self] response in
-                            guard self != nil else { return }
-                            guard let data = response?.data else { return }
-                            APIConstants.jwtToken = data.accessToken
-                            APIConstants.refreshToken = data.refreshToken
-                            UserDefaults.standard.set(data.accessToken, forKey: I18N.Auth.jwtToken)
-                            UserDefaults.standard.set(data.refreshToken, forKey: I18N.Auth.refreshToken)
-                            self?.retryOriginalRequest(observer: observer)
-                        }
-                    default:
-                        break
-                    }
-                    return Disposables.create()
-                }
-        }
-    }
-    
     /**
      해당 타입을 명시하여, 해당 타입으로 디코딩합니다.
      */
@@ -77,11 +53,5 @@ extension Observable where Element == Response {
                 return Disposables.create()
             }
         }
-    }
-    
-    
-    private func retryOriginalRequest(observer: AnyObserver<Response>) {
-        self.subscribe(observer)
-            .disposed(by: Self.disposeBag)
     }
 }

--- a/Growthook/Growthook/Global/Literals/StringLiterals.swift
+++ b/Growthook/Growthook/Global/Literals/StringLiterals.swift
@@ -109,5 +109,6 @@ enum I18N {
         static let nickname = "nickname"
         static let memberId = "memberId"
         static let jwtToken = "jwtToken"
+        static let refreshToken = "refreshToken"
     }
 }

--- a/Growthook/Growthook/Network/API/ActionList/ActionListService.swift
+++ b/Growthook/Growthook/Network/API/ActionList/ActionListService.swift
@@ -95,6 +95,7 @@ struct ActionListService: Networkable {
     static func getActionListPercent(with memberId: Int) -> Observable<Int> {
         return provider.rx.request(.getActionListPercent(memberId: memberId))
             .asObservable()
+            .mapAuthError()
             .mapError()
             .decode(decodeType: Int.self)
     }
@@ -107,6 +108,7 @@ struct ActionListService: Networkable {
     static func getDoingActionList(with memberId: Int) -> Observable<[ActionListDoingResponse]> {
         return provider.rx.request(.getActionListDoing(memberId: memberId))
             .asObservable()
+            .mapAuthError()
             .mapError()
             .decode(decodeType: [ActionListDoingResponse].self)
     }
@@ -119,6 +121,7 @@ struct ActionListService: Networkable {
     static func getFinishedActionList(with memberId: Int) -> Observable<[ActionListFinishedResponse]> {
         return provider.rx.request(.getActionListFinished(memberId: memberId))
             .asObservable()
+            .mapAuthError()
             .mapError()
             .decode(decodeType: [ActionListFinishedResponse].self)
     }
@@ -131,6 +134,7 @@ struct ActionListService: Networkable {
     static func patchActionListCompletion(with actionPlanId: Int) -> Observable<ActionListCompletionResponse> {
         return provider.rx.request(.patchActionListCompletion(actionPlanId: actionPlanId))
             .asObservable()
+            .mapAuthError()
             .mapError()
             .decode(decodeType: ActionListCompletionResponse.self)
     }
@@ -144,6 +148,7 @@ struct ActionListService: Networkable {
     static func getActionListReview(with actionPlanId: Int) -> Observable<ActionListReviewDetailResponse> {
         return provider.rx.request(.getActionListReview(actionPlanId: actionPlanId))
             .asObservable()
+            .mapAuthError()
             .mapError()
             .decode(decodeType: ActionListReviewDetailResponse.self)
     }
@@ -156,6 +161,7 @@ struct ActionListService: Networkable {
     static func postActionListReview(actionPlanId: Int, review: ActionListReviewPostRequest) -> Observable<ActionListReviewPostResponse> {
         return provider.rx.request(.postActionListReview(actionPlanId: actionPlanId, parameter: review))
             .asObservable()
+            .mapAuthError()
             .mapError()
             .decode(decodeType: ActionListReviewPostResponse.self)
     }

--- a/Growthook/Growthook/Network/API/ActionList/ActionListService.swift
+++ b/Growthook/Growthook/Network/API/ActionList/ActionListService.swift
@@ -95,7 +95,6 @@ struct ActionListService: Networkable {
     static func getActionListPercent(with memberId: Int) -> Observable<Int> {
         return provider.rx.request(.getActionListPercent(memberId: memberId))
             .asObservable()
-            .mapAuthError()
             .mapError()
             .decode(decodeType: Int.self)
     }
@@ -108,7 +107,6 @@ struct ActionListService: Networkable {
     static func getDoingActionList(with memberId: Int) -> Observable<[ActionListDoingResponse]> {
         return provider.rx.request(.getActionListDoing(memberId: memberId))
             .asObservable()
-            .mapAuthError()
             .mapError()
             .decode(decodeType: [ActionListDoingResponse].self)
     }
@@ -121,7 +119,6 @@ struct ActionListService: Networkable {
     static func getFinishedActionList(with memberId: Int) -> Observable<[ActionListFinishedResponse]> {
         return provider.rx.request(.getActionListFinished(memberId: memberId))
             .asObservable()
-            .mapAuthError()
             .mapError()
             .decode(decodeType: [ActionListFinishedResponse].self)
     }
@@ -134,7 +131,6 @@ struct ActionListService: Networkable {
     static func patchActionListCompletion(with actionPlanId: Int) -> Observable<ActionListCompletionResponse> {
         return provider.rx.request(.patchActionListCompletion(actionPlanId: actionPlanId))
             .asObservable()
-            .mapAuthError()
             .mapError()
             .decode(decodeType: ActionListCompletionResponse.self)
     }
@@ -148,7 +144,6 @@ struct ActionListService: Networkable {
     static func getActionListReview(with actionPlanId: Int) -> Observable<ActionListReviewDetailResponse> {
         return provider.rx.request(.getActionListReview(actionPlanId: actionPlanId))
             .asObservable()
-            .mapAuthError()
             .mapError()
             .decode(decodeType: ActionListReviewDetailResponse.self)
     }
@@ -161,7 +156,6 @@ struct ActionListService: Networkable {
     static func postActionListReview(actionPlanId: Int, review: ActionListReviewPostRequest) -> Observable<ActionListReviewPostResponse> {
         return provider.rx.request(.postActionListReview(actionPlanId: actionPlanId, parameter: review))
             .asObservable()
-            .mapAuthError()
             .mapError()
             .decode(decodeType: ActionListReviewPostResponse.self)
     }

--- a/Growthook/Growthook/Network/Base/APIConstant.swift
+++ b/Growthook/Growthook/Network/Base/APIConstant.swift
@@ -10,6 +10,7 @@ import Foundation
 enum NetworkHeaderKey: String {
     case deviceToken = "deviceToken"
     case accessToken = "accesstoken"
+    case refreshToken = "refreshToken"
     case contentType = "Content-Type"
     case authorization = "Authorization"
 }
@@ -21,7 +22,7 @@ enum APIConstants {
     static let applicationJSON = "application/json"
     static var deviceToken: String = ""
     static var jwtToken: String = UserDefaults.standard.string(forKey: I18N.Auth.jwtToken) ?? ""
-    static var refreshToken: String = ""
+    static var refreshToken: String = UserDefaults.standard.string(forKey: I18N.Auth.refreshToken) ?? ""
     
     //MARK: - Header
     
@@ -48,7 +49,8 @@ enum APIConstants {
     static var headerWithRefresh: [String: String] {
         [
             NetworkHeaderKey.contentType.rawValue: APIConstants.applicationJSON,
-            NetworkHeaderKey.authorization.rawValue: URLConstant.bearer + APIConstants.jwtToken
+            NetworkHeaderKey.authorization.rawValue: URLConstant.bearer + APIConstants.jwtToken,
+            NetworkHeaderKey.refreshToken.rawValue: URLConstant.bearer + APIConstants.refreshToken
         ]
     }
 }

--- a/Growthook/Growthook/Network/Base/APIConstant.swift
+++ b/Growthook/Growthook/Network/Base/APIConstant.swift
@@ -21,8 +21,8 @@ enum APIConstants {
     static let auth: String = "x-auth-token"
     static let applicationJSON = "application/json"
     static var deviceToken: String = ""
-    static var jwtToken: String = UserDefaults.standard.string(forKey: I18N.Auth.jwtToken) ?? ""
-    static var refreshToken: String = UserDefaults.standard.string(forKey: I18N.Auth.refreshToken) ?? ""
+    static var jwtToken: String = KeychainHelper.loadString(key: I18N.Auth.jwtToken) ?? ""
+    static var refreshToken: String = KeychainHelper.loadString(key: I18N.Auth.refreshToken) ?? ""
     
     //MARK: - Header
     

--- a/Growthook/Growthook/Presentation/ActionList/ViewModels/ActionListViewModel.swift
+++ b/Growthook/Growthook/Presentation/ActionList/ViewModels/ActionListViewModel.swift
@@ -52,7 +52,7 @@ final class ActionListViewModel: ActionListViewModelInput, ActionListViewModelOu
     var reviewDetail: BehaviorRelay<ActionListReviewDetailResponse> = BehaviorRelay<ActionListReviewDetailResponse>(value: ActionListReviewDetailResponse.actionListReviewDetailDummy())
     private let disposeBag = DisposeBag()
     var memberId: Int = UserDefaults.standard.integer(forKey: I18N.Auth.memberId)
-        
+    
     var inputs: ActionListViewModelInput { return self }
     var outputs: ActionListViewModelOutput { return self }
     
@@ -76,21 +76,22 @@ final class ActionListViewModel: ActionListViewModelInput, ActionListViewModelOu
     
     
     init() {
-        self.getActionListPercent()
-        self.getFinishedActionList()
-        self.getDoingActionList()
+        self.getActionListPercent(mamberId: memberId)
+        self.getFinishedActionList(mamberId: memberId)
+        self.getDoingActionList(mamberId: memberId)
+
     }
     
     func didTapInProgressButton() {
         selectedIndex.accept(1)
-        getDoingActionList()
-        getActionListPercent()
+        getDoingActionList(mamberId: memberId)
+        getActionListPercent(mamberId: memberId)
     }
     
     func didTapCompletedButton() {
         selectedIndex.accept(0)
-        getFinishedActionList()
-        getActionListPercent()
+        getFinishedActionList(mamberId: memberId)
+        getActionListPercent(mamberId: memberId)
     }
     
     func didTapInprogressScrapButton() {
@@ -107,7 +108,7 @@ final class ActionListViewModel: ActionListViewModelInput, ActionListViewModelOu
     }
     
     func didTapReviewButton(with actionPlanId: Int) {
-        getpostActionListReview(actionPlanId: actionPlanId)
+        getActionListReview(actionPlanId: actionPlanId)
     }
     
     func setReviewText(with value: String) {
@@ -116,40 +117,40 @@ final class ActionListViewModel: ActionListViewModelInput, ActionListViewModelOu
     
     func didTapCancelButtonInBottomSheet() {
         selectedIndex.accept(0)
-        getActionListPercent()
+        getActionListPercent(mamberId: memberId)
     }
     
     func didTapSaveButtonInBottomSheet() {
         selectedIndex.accept(0)
-        getActionListPercent()
+        getActionListPercent(mamberId: memberId)
     }
     
     func didTapCheckButtonInAcertView() {
-        getFinishedActionList()
-        getActionListPercent()
+        getFinishedActionList(mamberId: memberId)
+        getActionListPercent(mamberId: memberId)
     }
     
     func didTapCancelButtonWithPatch(with actionPlanId: Int) {
         patchActionPlanCompletion(actionPlanId: actionPlanId)
-        getFinishedActionList()
-        getActionListPercent()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            self.getFinishedActionList(mamberId: self.memberId)
+            self.getActionListPercent(mamberId: self.memberId)
+        }
     }
+
     
     func didTapCancelButtonInBottomSheetWithPost(with actionPlanId: Int) {
         postActionListReview(actionPlanId: actionPlanId)
         patchActionPlanCompletion(actionPlanId: actionPlanId)
-        getFinishedActionList()
-        getActionListPercent()
+        getFinishedActionList(mamberId: memberId)
+        getActionListPercent(mamberId: memberId)
     }
 }
 
-// memberID 값 받아와야함. 언제? ActionList 탭을 터치할 때 한 마디로 init 이 될 때
-
-
 extension ActionListViewModel {
     
-    private func getActionListPercent() {
-        ActionListService.getActionListPercent(with: memberId)
+    private func getActionListPercent(mamberId: Int) {
+        ActionListService.getActionListPercent(with: mamberId)
             .subscribe(onNext: { [weak self] data in
                 guard let self else { return }
                 self.titlePersent.accept("\(data)")
@@ -159,8 +160,8 @@ extension ActionListViewModel {
             .disposed(by: disposeBag)
     }
     
-    private func getDoingActionList() {
-        ActionListService.getDoingActionList(with: memberId)
+    private func getDoingActionList(mamberId: Int) {
+        ActionListService.getDoingActionList(with: mamberId)
             .subscribe(onNext: { [weak self] data in
                 guard let self else { return }
                 self.doingActionList.accept(data)
@@ -171,9 +172,9 @@ extension ActionListViewModel {
             .disposed(by: disposeBag)
     }
     
-    private func getFinishedActionList() {
+    private func getFinishedActionList(mamberId: Int) {
         print("getFinishedActionList가 호출됩니다")
-        ActionListService.getFinishedActionList(with: memberId)
+        ActionListService.getFinishedActionList(with: mamberId)
             .subscribe(onNext: { [weak self] data in
                 guard let self else { return }
                 self.finishedActionList.accept(data)
@@ -195,7 +196,6 @@ extension ActionListViewModel {
     
     private func postActionListReview(actionPlanId: Int) {
         let newReview = ActionListReviewPostRequest(content: reviewText.value)
-        
         ActionListService.postActionListReview(actionPlanId: actionPlanId, review: newReview)
             .subscribe(onNext: { [weak self] _ in
                 guard let self else { return }
@@ -208,8 +208,8 @@ extension ActionListViewModel {
             .disposed(by: disposeBag)
     }
     
-    private func getpostActionListReview(actionPlanId: Int) {
-        print("getpostActionListReview가 호출됩니다")
+    private func getActionListReview(actionPlanId: Int) {
+        print("getActionListReview가 호출됩니다")
         ActionListService.getActionListReview(with: actionPlanId)
             .subscribe(onNext: { [weak self] data in
                 guard let self else { return }

--- a/Growthook/Growthook/Presentation/Mypage/ViewModels/MyPageViewModel.swift
+++ b/Growthook/Growthook/Presentation/Mypage/ViewModels/MyPageViewModel.swift
@@ -94,10 +94,10 @@ final class MyPageViewModel: MyPageViewModelInputs, MyPageViewModelOutputs, MyPa
     
     func logOutDidTap() {
         print("LogOut Tapped")
-        APIConstants.jwtToken = ""
-        APIConstants.refreshToken = ""
         UserDefaults.standard.removeObject(forKey: I18N.Auth.nickname)
         UserDefaults.standard.removeObject(forKey: I18N.Auth.memberId)
+        UserDefaults.standard.removeObject(forKey: I18N.Auth.jwtToken)
+        UserDefaults.standard.removeObject(forKey: I18N.Auth.refreshToken)
         UserDefaults.standard.set(false ,forKey: "isLoggedIn")
     }
 }

--- a/Growthook/Growthook/Presentation/Mypage/ViewModels/MyPageViewModel.swift
+++ b/Growthook/Growthook/Presentation/Mypage/ViewModels/MyPageViewModel.swift
@@ -96,8 +96,10 @@ final class MyPageViewModel: MyPageViewModelInputs, MyPageViewModelOutputs, MyPa
         print("LogOut Tapped")
         UserDefaults.standard.removeObject(forKey: I18N.Auth.nickname)
         UserDefaults.standard.removeObject(forKey: I18N.Auth.memberId)
-        UserDefaults.standard.removeObject(forKey: I18N.Auth.jwtToken)
-        UserDefaults.standard.removeObject(forKey: I18N.Auth.refreshToken)
+//        UserDefaults.standard.removeObject(forKey: I18N.Auth.jwtToken)
+//        UserDefaults.standard.removeObject(forKey: I18N.Auth.refreshToken)
+        KeychainHelper.delete(key: I18N.Auth.jwtToken)
+        KeychainHelper.delete(key: I18N.Auth.refreshToken)
         UserDefaults.standard.set(false ,forKey: "isLoggedIn")
     }
 }

--- a/Growthook/Growthook/Presentation/Onboarding/ViewControllers/LoginViewController.swift
+++ b/Growthook/Growthook/Presentation/Onboarding/ViewControllers/LoginViewController.swift
@@ -151,9 +151,12 @@ final class LoginViewController: BaseViewController {
             guard let data = response?.data else { return }
             APIConstants.jwtToken = data.accessToken
             APIConstants.refreshToken = data.refreshToken
+            UserDefaults.standard.set(data.accessToken, forKey: I18N.Auth.jwtToken)
+            UserDefaults.standard.set(data.refreshToken, forKey: I18N.Auth.refreshToken)
             UserDefaults.standard.set(data.nickname, forKey: I18N.Auth.nickname)
             UserDefaults.standard.set(data.memberId, forKey: I18N.Auth.memberId)
             UserDefaults.standard.set(true ,forKey: "isLoggedIn")
+            UserDefaults.standard.set(true ,forKey: "isAppleLogin")
             /**
              위는 사용자가 로그인을 했는지 안 했는지 확인하는
              UserDefaults입니다.  SplashViewController의 96번 줄을 보세요
@@ -161,7 +164,7 @@ final class LoginViewController: BaseViewController {
             self?.loginSuccess()
         }
     }
-    // KJrnjswjd9470
+
     private func getNewToken() {
         AuthAPI.shared.getRefreshToken() { [weak self] response in
             guard self != nil else { return }

--- a/Growthook/Growthook/Presentation/Onboarding/ViewControllers/LoginViewController.swift
+++ b/Growthook/Growthook/Presentation/Onboarding/ViewControllers/LoginViewController.swift
@@ -156,6 +156,8 @@ final class LoginViewController: BaseViewController {
             UserDefaults.standard.set(data.nickname, forKey: I18N.Auth.nickname)
             UserDefaults.standard.set(data.memberId, forKey: I18N.Auth.memberId)
             UserDefaults.standard.set(true ,forKey: "isLoggedIn")
+            
+            
             UserDefaults.standard.set(true ,forKey: "isAppleLogin")
             /**
              위는 사용자가 로그인을 했는지 안 했는지 확인하는

--- a/Growthook/Growthook/Presentation/Onboarding/ViewControllers/LoginViewController.swift
+++ b/Growthook/Growthook/Presentation/Onboarding/ViewControllers/LoginViewController.swift
@@ -151,8 +151,16 @@ final class LoginViewController: BaseViewController {
             guard let data = response?.data else { return }
             APIConstants.jwtToken = data.accessToken
             APIConstants.refreshToken = data.refreshToken
-            UserDefaults.standard.set(data.accessToken, forKey: I18N.Auth.jwtToken)
-            UserDefaults.standard.set(data.refreshToken, forKey: I18N.Auth.refreshToken)
+//            UserDefaults.standard.set(data.accessToken, forKey: I18N.Auth.jwtToken)
+//            UserDefaults.standard.set(data.refreshToken, forKey: I18N.Auth.refreshToken)
+            
+            if let accessTokenData = data.accessToken.data(using: .utf8) {
+                KeychainHelper.save(key: I18N.Auth.jwtToken, data: accessTokenData)
+            }
+
+            if let refreshTokenData = data.refreshToken.data(using: .utf8) {
+                KeychainHelper.save(key: I18N.Auth.refreshToken, data: refreshTokenData)
+            }
             UserDefaults.standard.set(data.nickname, forKey: I18N.Auth.nickname)
             UserDefaults.standard.set(data.memberId, forKey: I18N.Auth.memberId)
             UserDefaults.standard.set(true ,forKey: "isLoggedIn")


### PR DESCRIPTION
## 🌿 문제

<!-- 작업하게 된 배경을 간단히 적어주세요! -->
- 로그인 이후 앱을 종료하고 다시 실행하여도 로그인 상태가 유지 되도록 구현

## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- `SplashViewController`에서 현재 유저가 기존에 로그인을 하고 로그아웃을 하지 않은 상태면 UserDefaults에서 토큰을 가지고 와 서버와 통신이 진행되도록 구현했습니다
- 서버 통신을 진행할 때 accessToken이 만료될 경우 refreshToken을 자동으로 재발급 받을 수 있도록 처리했습니다 -> 이 부분은 앱이 실행 되는 과정에서 `SplashViewController`에서 토큰의 유효성 검사를 진행하여 만약 유효하지 않다면 재발급을 받거나 재발급 마저 받을 수 없다면 Onboarding으로, 유효하다면 그대로 TarBar로 이동합니다
- 로그아웃을 할 경우 서버로 부터 받은 앱내의 정보를 모두 제거한 뒤 `isLoggedIn`의 값을 처리하여 다시 앱을 실행 할 경우 온보딩 부터 시작되게 처리하였습니다
- 회원탈퇴의 경우 아직 서버로부터 미 구현이며 구현 될 경우 바로 작업할 예정입니다.
- UserDefaults에서 관리하던 토큰들을 Keychain으로 변경하였습니다. 이 부분은 현재는 주석처리를 하였으며, 주석 처리를 한 이유는 다른 소셜 로그인을 담당하는 @kj9470 가 현재 코드에선 UserDefaults로 되었기에 어떤 부분이 바뀐지 체크하기 위함입니다

## 🍀 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #71
