### PR TITLE
[Feat] #73 - 카카오 로그인 구현 

### DIFF
--- a/Growthook/Growthook/Network/API/Auth/AuthAPI.swift
+++ b/Growthook/Growthook/Network/API/Auth/AuthAPI.swift
@@ -50,6 +50,12 @@ final class AuthAPI {
                 do {
                     self.refreshTokenData = try response.map(GeneralResponse<RefreshTokenResponseDto>?.self)
                     guard let refreshTokenData = self.refreshTokenData else { return }
+                    if let accessToken = refreshTokenData.data?.accessToken.data(using: .utf8) {
+                        KeychainHelper.save(key: I18N.Auth.jwtToken, data: accessToken)
+                    }
+                    if let refreshToken = refreshTokenData.data?.refreshToken.data(using: .utf8) {
+                        KeychainHelper.save(key: I18N.Auth.refreshToken, data: refreshToken)
+                    }
                     completion(refreshTokenData)
                 } catch let err {
                     print(err.localizedDescription, 500)

--- a/Growthook/Growthook/Network/API/Auth/AuthAPI.swift
+++ b/Growthook/Growthook/Network/API/Auth/AuthAPI.swift
@@ -60,4 +60,25 @@ final class AuthAPI {
             }
         }
     }
+    
+    // MARK: - DELETE
+    /// 회원 탈퇴
+    func deleteMemberWithdraw(memberId: Int, completion: @escaping (GeneralResponse<VoidType>?) -> Void) {
+        authProvider.request(.withdraw(memberId: memberId)) {
+            result in
+            switch result {
+            case .success(let response):
+                do {
+                    let data = try response.map(GeneralResponse<VoidType>?.self)
+                    completion(data)
+                } catch let err {
+                    print(err.localizedDescription, 500)
+                }
+            case .failure(let err)
+                :
+                print(err.localizedDescription)
+                completion(nil)
+            }
+        }
+    }
 }

--- a/Growthook/Growthook/Network/API/Auth/AuthAPI.swift
+++ b/Growthook/Growthook/Network/API/Auth/AuthAPI.swift
@@ -80,8 +80,7 @@ final class AuthAPI {
                 } catch let err {
                     print(err.localizedDescription, 500)
                 }
-            case .failure(let err)
-                :
+            case .failure(let err):
                 print(err.localizedDescription)
                 completion(nil)
             }

--- a/Growthook/Growthook/Network/APIService/Auth/AuthTarget.swift
+++ b/Growthook/Growthook/Network/APIService/Auth/AuthTarget.swift
@@ -12,6 +12,7 @@ import Moya
 enum AuthTarget {
     case login(param: LoginRequestDto)
     case tokenRefresh
+    case withdraw(memberId: Int)
 }
 
 extension AuthTarget: BaseTargetType {
@@ -22,6 +23,9 @@ extension AuthTarget: BaseTargetType {
             return URLConstant.socialLogin
         case .tokenRefresh:
             return URLConstant.tokenRefresh
+        case .withdraw(memberId: let memberId):
+            let path = URLConstant.memberWithdraw.replacingOccurrences(of: "{memberId}", with: String(memberId))
+            return path
         }
     }
     
@@ -31,6 +35,8 @@ extension AuthTarget: BaseTargetType {
             return .post
         case .tokenRefresh:
             return .get
+        case .withdraw:
+            return .delete
         }
     }
     
@@ -39,6 +45,8 @@ extension AuthTarget: BaseTargetType {
         case .login(let param):
             return .requestParameters(parameters: try! param.asParameter(), encoding: JSONEncoding.default)
         case .tokenRefresh:
+            return .requestPlain
+        case .withdraw:
             return .requestPlain
         }
     }
@@ -49,6 +57,8 @@ extension AuthTarget: BaseTargetType {
             return APIConstants.headerWithOutToken
         case .tokenRefresh:
             return APIConstants.headerWithRefresh
+        case .withdraw:
+            return APIConstants.headerWithAuthorization
         }
     }
 }

--- a/Growthook/Growthook/Network/Base/URLConstant.swift
+++ b/Growthook/Growthook/Network/Base/URLConstant.swift
@@ -67,4 +67,5 @@ enum URLConstant {
     static let socialLogin = "/api/v1/auth"
     static let tokenRefresh = "/api/v1/auth/token"
     static let bearer = "Bearer "
+    static let memberWithdraw = "/api/v1/member/{memberId}"
 }

--- a/Growthook/Growthook/Presentation/Home/ViewModels/HomeViewModel.swift
+++ b/Growthook/Growthook/Presentation/Home/ViewModels/HomeViewModel.swift
@@ -311,4 +311,13 @@ extension HomeViewModel {
             self?.ssukCount.accept(data)
         }
     }
+    
+    private func getNewToken() {
+        AuthAPI.shared.getRefreshToken() { [weak self] response in
+            guard self != nil else { return }
+            guard let data = response?.data else { return }
+            APIConstants.jwtToken = data.accessToken
+            APIConstants.refreshToken = data.refreshToken
+        }
+    }
 }

--- a/Growthook/Growthook/Presentation/Mypage/Controllers/MyPageUserInformationViewController.swift
+++ b/Growthook/Growthook/Presentation/Mypage/Controllers/MyPageUserInformationViewController.swift
@@ -54,7 +54,28 @@ final class MyPageUserInformationViewController: BaseViewController {
         withdrawalButton.rx.tap
             .bind { [weak self] in
                 let loginType = UserDefaults.standard.string(forKey: I18N.Auth.loginType)
-                print(loginType)
+                let memberId = UserDefaults.standard.integer(forKey: I18N.Auth.memberId)
+                AuthAPI.shared.deleteMemberWithdraw(memberId: memberId) {
+                    [weak self] response in
+                    guard self != nil else { return }
+                    
+                    // UserDefault 삭제
+                    
+                    
+                    // 루트 뷰 변경
+                        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                           let sceneDelegate = windowScene.delegate as? SceneDelegate,
+                           let window = sceneDelegate.window {
+                            let vc = SplashViewController()
+                            let rootVC = UINavigationController(rootViewController: vc)
+                            rootVC.view.showToast(message: I18N.Component.ToastMessage.removeCave)
+                            rootVC.navigationController?.isNavigationBarHidden = true
+                            window.rootViewController = rootVC
+                            window.makeKeyAndVisible()
+                        }
+                    
+                    print("회원탈퇴 완료")
+                }
             }
             .disposed(by: disposeBag)
     }

--- a/Growthook/Growthook/Presentation/Mypage/Controllers/MyPageUserInformationViewController.swift
+++ b/Growthook/Growthook/Presentation/Mypage/Controllers/MyPageUserInformationViewController.swift
@@ -60,7 +60,9 @@ final class MyPageUserInformationViewController: BaseViewController {
                     guard self != nil else { return }
                     
                     // UserDefault 삭제
-                    
+                    _ = UserDefaults.standard.dictionaryRepresentation().map {
+                        UserDefaults.standard.removeObject(forKey: $0.key)
+                    }
                     
                     // 루트 뷰 변경
                         if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
@@ -68,7 +70,6 @@ final class MyPageUserInformationViewController: BaseViewController {
                            let window = sceneDelegate.window {
                             let vc = SplashViewController()
                             let rootVC = UINavigationController(rootViewController: vc)
-                            rootVC.view.showToast(message: I18N.Component.ToastMessage.removeCave)
                             rootVC.navigationController?.isNavigationBarHidden = true
                             window.rootViewController = rootVC
                             window.makeKeyAndVisible()

--- a/Growthook/Growthook/Presentation/Onboarding/ViewControllers/LoginViewController.swift
+++ b/Growthook/Growthook/Presentation/Onboarding/ViewControllers/LoginViewController.swift
@@ -135,11 +135,19 @@ final class LoginViewController: BaseViewController {
             guard let data = response?.data else { return }
             APIConstants.jwtToken = data.accessToken
             APIConstants.refreshToken = data.refreshToken
+            if let accessTokenData = data.accessToken.data(using: .utf8) {
+                KeychainHelper.save(key: I18N.Auth.jwtToken, data: accessTokenData)
+            }
+
+            if let refreshTokenData = data.refreshToken.data(using: .utf8) {
+                KeychainHelper.save(key: I18N.Auth.refreshToken, data: refreshTokenData)
+            }
             UserDefaults.standard.set(data.nickname, forKey: I18N.Auth.nickname)
             UserDefaults.standard.set(data.memberId, forKey: I18N.Auth.memberId)
-            UserDefaults.standard.set(data.accessToken, forKey: I18N.Auth.jwtToken)
+//            UserDefaults.standard.set(data.accessToken, forKey: I18N.Auth.jwtToken)
             UserDefaults.standard.set(true ,forKey: I18N.Auth.isLoggedIn)
             UserDefaults.standard.set(I18N.Auth.kakao, forKey: I18N.Auth.loginType)
+            
             self?.loginSuccess()
         }
     }


### PR DESCRIPTION
## 🌿 문제

<!-- 작업하게 된 배경을 간단히 적어주세요! -->
- 카카오 소셜 로그인 구현

## 🌱 작업한 내용

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- 일단 규보오빠 뷰 풀을 못받아서, 회원탈퇴 버튼 눌렸을 때 서버통신 하도록 구현했습니다.
- 탈퇴 성공하면 UserDefault 변경하고, 루트뷰도 온보딩으로 변경했습니다.
- 충돌 날까봐 ViewModel은 안건드렸어요 !

## 🍀 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #73 
